### PR TITLE
Package for PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ The directory `original_code/` contains initial notebooks compiled from recent p
 The functionality of these notebooks is being ported to the `asp_plot/` directory, which is the package `asp_plot`.
 
 
-## Installing and testing the package
+## Installing, testing, and distributing the package
+
+### For Development
+
+If you instead want to install the source code for e.g. developing the project:
 
 ```
 $ git clone git@github.com:uw-cryo/asp_plot.git
@@ -31,6 +35,21 @@ To ensure the install was successful, tests can be run with:
 
 ```
 $ pytest
+```
+
+### Package and upload
+
+```
+$ python3 -m pip install --upgrade build
+$ python3 -m build
+$ python3 -m pip install --upgrade twine
+$ python3 -m twine upload dist/*
+```
+
+### Install via pip
+
+```
+pip install asp-plot
 ```
 
 ## Notebook example usage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "asp_plot"
+version = "0.0.2"
+authors = [
+  { name="Ben Purinton", email="purinton@uw.edu" },
+]
+description = "Package for plotting outputs Ames Stereo Pipeline processing"
+readme = "README.md"
+requires-python = ">=3.11"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: BSD License",
+    "Operating System :: OS Independent",
+]
+
+[project.urls]
+Homepage = "https://github.com/uw-cryo/asp_plot"
+Issues = "https://github.com/uw-cryo/asp_plot/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 
+[project.scripts]
+asp_plot = "asp_plot.cli.asp_plot:main"
+
 [project.urls]
 Homepage = "https://github.com/uw-cryo/asp_plot"
 Issues = "https://github.com/uw-cryo/asp_plot/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "asp_plot"
-version = "0.0.1"
+version = "0.1.0"
 authors = [
   { name="Ben Purinton", email="purinton@uw.edu" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "asp_plot"
-version = "0.0.2"
+version = "0.0.1"
 authors = [
   { name="Ben Purinton", email="purinton@uw.edu" },
 ]

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="asp_plot",
-    version="0.1.0",
+    version="0.0.2",
     description="Python library and client for plotting Ames Stereo Pipeline outputs",
     author="Ben Purinton",
     author_email="purinton@uw.edu",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="asp_plot",
-    version="0.0.1",
+    version="0.1.0",
     description="Python library and client for plotting Ames Stereo Pipeline outputs",
     author="Ben Purinton",
     author_email="purinton@uw.edu",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="asp_plot",
-    version="0.0.2",
+    version="0.0.1",
     description="Python library and client for plotting Ames Stereo Pipeline outputs",
     author="Ben Purinton",
     author_email="purinton@uw.edu",


### PR DESCRIPTION
Would be cool if I could get this to:

```
pip install asp-plot
```

Having some trouble getting the CLI to register though.

Here is the page to eventually distribute to: https://pypi.org/manage/project/asp-plot/releases/

Helpful resource: https://packaging.python.org/en/latest/tutorials/packaging-projects/

---

I think it's working now actually, after this commit: https://github.com/uw-cryo/asp_plot/pull/14/commits/fe51fb15f8658837c4c37d15c8110923a4b7602c