### PR TITLE
Improve title and filename for report

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,23 +31,39 @@ Examples of the modular usage of the package can be found in the `notebooks/` di
 A full report and individual plots can be output via the command-line:
 
 ```
-$ asp_plot --directory ./asp_processing \
+$ asp_plot --directory ./ \
            --bundle_adjust_directory ba \
            --stereo_directory stereo \
            --map_crs EPSG:32604 \
-           --reference_dem ref_dem.tif \
-           --plots_directory asp_plots \
-           --report_filename asp_plot_report.pdf \
-           --report_title "Scene X and Y"
+           --reference_dem ref_dem.tif
 ```
 
-Use:
+Before that, we recommend running `asp_plot --help` for details (and defaults) of all of the command-line flags:
 
 ```
-$ asp_plot --help
-```
+ $ asp_plot --help
+Usage: asp_plot [OPTIONS]
 
-for details (and defaults) of the command-line flags.
+Options:
+  --directory TEXT                Directory of ASP processing with scenes and
+                                  sub-directories for bundle adjustment and
+                                  stereo. Default: current directory
+  --bundle_adjust_directory TEXT  Directory of bundle adjustment files.
+                                  Default: ba
+  --stereo_directory TEXT         Directory of stereo files. Default: stereo
+  --map_crs TEXT                  Projection for bundle adjustment plots.
+                                  Default: EPSG:4326
+  --reference_dem TEXT            Reference DEM used in ASP processing. No
+                                  default. Must be supplied.
+  --plots_directory TEXT          Directory to put output plots. Default:
+                                  asp_plots
+  --report_filename TEXT          PDF file to write out for report into the
+                                  processing directory supplied by
+                                  --directory. Default: Directory name of ASP
+                                  processing
+  --report_title TEXT             Title for the report. Default: Directory
+                                  name of ASP processing
+```
 
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ $ asp_plot --directory ./asp_processing \
            --map_crs EPSG:32604 \
            --reference_dem ref_dem.tif \
            --plots_directory asp_plots \
-           --report_filename asp_plot_report.pdf
+           --report_filename asp_plot_report.pdf \
+           --report_title "Scene X and Y"
 ```
 
 Use:

--- a/asp_plot/cli/asp_plot.py
+++ b/asp_plot/cli/asp_plot.py
@@ -40,7 +40,7 @@ from asp_plot.utils import compile_report
     "--reference_dem",
     prompt=True,
     default="",
-    help="Reference DEM used in ASP processing. Default: ",
+    help="Reference DEM used in ASP processing. No default. Must be supplied.",
 )
 @click.option(
     "--plots_directory",

--- a/asp_plot/cli/asp_plot.py
+++ b/asp_plot/cli/asp_plot.py
@@ -44,15 +44,21 @@ from asp_plot.utils import compile_report
 )
 @click.option(
     "--plots_directory",
-    prompt=True,
+    prompt=False,
     default="asp_plots_for_report",
     help="Directory to put output plots. Default: asp_plots",
 )
 @click.option(
     "--report_filename",
-    prompt=True,
-    default="asp_plot_report.pdf",
-    help="PDF file to write out for report. Default: asp_plot_report.pdf",
+    prompt=False,
+    default=None,
+    help="PDF file to write out for report into the processing directory supplied by --directory. Default: Directory name of ASP processing",
+)
+@click.option(
+    "--report_title",
+    prompt=False,
+    default=None,
+    help="Title for the report. Default: Directory name of ASP processing",
 )
 def main(
     directory,
@@ -62,11 +68,15 @@ def main(
     reference_dem,
     plots_directory,
     report_filename,
+    report_title,
 ):
     print(f"\n\nProcessing ASP files in {directory}\n\n")
 
     plots_directory = os.path.join(directory, plots_directory)
     os.makedirs(plots_directory, exist_ok=True)
+
+    if report_filename is None:
+        report_filename = f"asp_plot_report_{os.path.split(directory.rstrip("/\\"))[-1]:}.pdf"
     report_pdf_path = os.path.join(directory, report_filename)
 
     figure_counter = count(0)
@@ -74,12 +84,16 @@ def main(
     # Geometry plot
     plotter = SceneGeometryPlotter(directory)
 
-    plotter.dg_geom_plot(save_dir=plots_directory, fig_fn=f"{next(figure_counter):02}.png")
+    plotter.dg_geom_plot(
+        save_dir=plots_directory, fig_fn=f"{next(figure_counter):02}.png"
+    )
 
     # Scene plot
     plotter = ScenePlotter(directory, stereo_directory, title="Mapprojected Scenes")
 
-    plotter.plot_orthos(save_dir=plots_directory, fig_fn=f"{next(figure_counter):02}.png")
+    plotter.plot_orthos(
+        save_dir=plots_directory, fig_fn=f"{next(figure_counter):02}.png"
+    )
 
     # Bundle adjustment plots
     ba_files = ReadBundleAdjustFiles(directory, bundle_adjust_directory)
@@ -139,10 +153,13 @@ def main(
     plotter = PlotBundleAdjustFiles(
         [geodiff_initial_gdf, geodiff_final_gdf],
         lognorm=False,
-        title="Bundle Adjust Initial and Final Geodiff vs. Reference DEM"
+        title="Bundle Adjust Initial and Final Geodiff vs. Reference DEM",
     )
 
-    clim = (float(geodiff_initial_gdf["height_diff_meters"].quantile(0.05)), float(geodiff_initial_gdf["height_diff_meters"].quantile(0.95)))
+    clim = (
+        float(geodiff_initial_gdf["height_diff_meters"].quantile(0.05)),
+        float(geodiff_initial_gdf["height_diff_meters"].quantile(0.95)),
+    )
     abs_max = max(abs(clim[0]), abs(clim[1]))
     clim = (-abs_max, abs_max)
 
@@ -154,7 +171,7 @@ def main(
         clim=clim,
         save_dir=plots_directory,
         fig_fn=f"{next(figure_counter):02}.png",
-        **ctx_kwargs
+        **ctx_kwargs,
     )
 
     # Stereo plots
@@ -193,7 +210,12 @@ def main(
     )
     processing_parameters_dict = processing_parameters.from_log_files()
 
-    compile_report(plots_directory, processing_parameters_dict, report_pdf_path)
+    compile_report(
+        plots_directory,
+        processing_parameters_dict,
+        report_pdf_path,
+        report_title=report_title,
+    )
 
     print(f"\n\nReport saved to {report_pdf_path}\n\n")
 

--- a/asp_plot/stereopair_metadata_parser.py
+++ b/asp_plot/stereopair_metadata_parser.py
@@ -8,6 +8,7 @@ from osgeo import ogr, osr, gdal
 from shapely import wkt
 from asp_plot.utils import get_xml_tag
 
+osr.UseExceptions()
 
 class StereopairMetadataParser:
     def __init__(self, directory):

--- a/asp_plot/utils.py
+++ b/asp_plot/utils.py
@@ -31,7 +31,9 @@ def save_figure(fig, save_dir=None, fig_fn=None, dpi=150):
         raise ValueError("Please provide a save directory and figure filename")
 
 
-def compile_report(plots_directory, processing_parameters_dict, report_pdf_path):
+def compile_report(
+    plots_directory, processing_parameters_dict, report_pdf_path, report_title=None
+):
     from PIL import Image
 
     files = [f for f in os.listdir(plots_directory) if f.endswith(".png")]
@@ -50,16 +52,22 @@ def compile_report(plots_directory, processing_parameters_dict, report_pdf_path)
 
         compressed_files.append(jpg_file)
 
-    processing_date = (
-        f"Processed on: {processing_parameters_dict['processing_timestamp']:}"
+    processing_date = processing_parameters_dict["processing_timestamp"]
+
+    if report_title is None:
+        report_title = os.path.basename(os.path.dirname(report_pdf_path))
+
+    report_title = (
+        f"# ASP Report\n\n## {report_title:}\n\nProcessed on: {processing_date:}"
     )
+
     ba_string = f"### Bundle Adjust:\n\n{processing_parameters_dict['bundle_adjust']:}"
     stereo_string = f"### Stereo:\n\n{processing_parameters_dict['stereo']:}"
     point2dem_string = f"### point2dem:\n\n{processing_parameters_dict['point2dem']:}"
 
     pdf = MarkdownPdf()
 
-    pdf.add_section(Section(f"# ASP Report, {processing_date:}\n\n"))
+    pdf.add_section(Section(f"{report_title:}\n\n"))
     pdf.add_section(
         Section(
             f"## Processing Parameters\n\n{ba_string:}\n\n{stereo_string}\n\n{point2dem_string}\n\n"


### PR DESCRIPTION
Resolves https://github.com/uw-cryo/asp_plot/issues/20

This PR allows a user to supply title for the report, and extends the functionality of the current filename for the report. If no title or filename is supplied, then the default is to use the name of the directory where the processed files are stored (which usually contains some identifying information about the scenes and their dates).

Also snuck in `osr.UseExceptions()` to silence a deprecation warning.