### PR TITLE
Cleanup geoutils and xdem dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,4 @@ dmypy.json
 scratch/
 notebooks/*.parquet
 notebooks/*.csv
+CLAUDE*

--- a/asp_plot/altimetry.py
+++ b/asp_plot/altimetry.py
@@ -4,11 +4,11 @@ import os
 
 import contextily as ctx
 import geopandas as gpd
-import geoutils as gu
 import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+import rasterio as rio
 import rioxarray
 import xarray as xr
 from sliderule import icesat2
@@ -921,13 +921,15 @@ class Altimetry:
         if plot_dem:
             ctx_kwargs = {}
             # We downsample to speed plotting. This is not carried over into any analysis.
-            dem_downsampled = gu.Raster(self.dem_fn, downsample=10)
+            dem_downsampled = Raster(self.dem_fn, downsample=10)
             cb = ColorBar(perc_range=(2, 98))
             cb.get_clim(dem_downsampled.data)
-            dem_downsampled.plot(
+            # Plot using rasterio's show function
+            rio.plot.show(
+                dem_downsampled.data,
+                transform=dem_downsampled.transform,
                 ax=ax,
                 cmap="inferno",
-                add_cbar=False,
                 vmin=cb.clim[0],
                 vmax=cb.clim[1],
                 alpha=1,

--- a/asp_plot/utils.py
+++ b/asp_plot/utils.py
@@ -4,7 +4,6 @@ import os
 import subprocess
 
 import contextily as ctx
-import geoutils as gu
 import matplotlib.colors
 import matplotlib.image as mpimg
 import matplotlib.pyplot as plt
@@ -491,6 +490,12 @@ class Raster:
         Path to the raster file
     ds : rasterio.DatasetReader
         Open rasterio dataset
+    downsample : int or float
+        Downsampling factor for reading data
+    data : numpy.ma.MaskedArray or None
+        Cached raster data (loaded on demand)
+    transform : affine.Affine
+        Affine transform for the raster (adjusted if downsampled)
 
     Examples
     --------
@@ -499,9 +504,12 @@ class Raster:
     >>> hillshade = raster.hillshade()
     >>> epsg = raster.get_epsg_code()
     >>> gsd = raster.get_gsd()
+    >>> # Downsample for faster plotting
+    >>> raster_ds = Raster("path/to/dem.tif", downsample=10)
+    >>> raster_ds.plot(ax=ax, cmap="viridis")
     """
 
-    def __init__(self, fn):
+    def __init__(self, fn, downsample=1):
         """
         Initialize the Raster object.
 
@@ -509,9 +517,67 @@ class Raster:
         ----------
         fn : str
             Path to the raster file
+        downsample : int or float, optional
+            Downsampling factor for reading data, default is 1 (no downsampling)
         """
         self.fn = fn
         self.ds = rio.open(fn)
+        self.downsample = downsample
+        self._data = None
+        self._transform = self.ds.transform
+
+    @property
+    def data(self):
+        """
+        Lazy-loaded raster data.
+
+        Returns
+        -------
+        numpy.ma.MaskedArray
+            Raster data (loaded on first access)
+        """
+        if self._data is None:
+            self._data = self.read_array()
+        return self._data
+
+    @property
+    def transform(self):
+        """
+        Get the affine transform for the raster.
+
+        Returns
+        -------
+        affine.Affine
+            Affine transform (adjusted for downsampling if applicable)
+        """
+        return self._transform
+
+    def _calculate_downsampled_shape(self):
+        """
+        Calculate the output shape for downsampled reading.
+
+        Returns
+        -------
+        tuple or None
+            (height, width) if downsampling is needed, None otherwise
+
+        Notes
+        -----
+        Also updates the internal transform to account for downsampling.
+        """
+        if self.downsample == 1:
+            return None
+
+        height = int(np.ceil(self.ds.height / self.downsample))
+        width = int(np.ceil(self.ds.width / self.downsample))
+
+        # Update transform for downsampled data
+        res = tuple(np.asarray(self.ds.res) * self.downsample)
+        self._transform = rio.transform.from_origin(
+            self.ds.bounds.left, self.ds.bounds.top, res[0], res[1]
+        )
+
+        return (height, width)
 
     def read_array(self, b=1, extent=False):
         """
@@ -533,8 +599,16 @@ class Raster:
         Notes
         -----
         No-data values are properly masked, and invalid values are fixed.
+        If downsample > 1, reads a downsampled version of the raster.
         """
-        a = self.ds.read(b, masked=True)
+        # Calculate downsampled shape if needed
+        out_shape = self._calculate_downsampled_shape()
+
+        if out_shape is not None:
+            a = self.ds.read(b, out_shape=out_shape, masked=True)
+        else:
+            a = self.ds.read(b, masked=True)
+
         ndv = self.get_ndv()
         ma = np.ma.fix_invalid(np.ma.masked_equal(a, ndv))
         out = ma
@@ -667,7 +741,7 @@ class Raster:
             hillshade = np.ma.masked_equal(hs_ds.ReadAsArray(), 0)
         return hillshade
 
-    def compute_difference(self, second_fn):
+    def compute_difference(self, second_fn, save=False):
         """
         Compute the difference between this raster and another.
 
@@ -675,6 +749,8 @@ class Raster:
         ----------
         second_fn : str
             Path to the second raster file
+        save : bool, optional
+            Whether to save the difference raster to disk, default is False
 
         Returns
         -------
@@ -683,23 +759,141 @@ class Raster:
 
         Notes
         -----
-        Uses geoutils to align rasters before differencing.
-        Saves the difference raster to disk with "_diff.tif" suffix.
+        Aligns rasters to the grid of the second raster before differencing.
+        If save=True, saves the difference raster with "_diff.tif" suffix.
         """
-        fn_list = [self.fn, second_fn]
-        outdir = os.path.dirname(os.path.abspath(self.fn))
+        # Load and align rasters, with second raster as reference
+        diff_data = self.load_and_diff_rasters(self.fn, second_fn)
 
-        outprefix = (
-            os.path.splitext(os.path.split(self.fn)[1])[0]
-            + "_"
-            + os.path.splitext(os.path.split(second_fn)[1])[0]
-        )
+        # Optionally save difference raster
+        if save:
+            outdir = os.path.dirname(os.path.abspath(self.fn))
+            outprefix = (
+                os.path.splitext(os.path.split(self.fn)[1])[0]
+                + "_"
+                + os.path.splitext(os.path.split(second_fn)[1])[0]
+            )
+            dst_fn = os.path.join(outdir, outprefix + "_diff.tif")
+            self.save_raster(diff_data, dst_fn, reference_fn=second_fn)
 
-        rasters = gu.raster.load_multiple_rasters(fn_list, ref_grid=1)
-        diff = rasters[1] - rasters[0]
-        dst_fn = os.path.join(outdir, outprefix + "_diff.tif")
-        diff.save(dst_fn)
-        return diff.data
+        return diff_data
+
+    @staticmethod
+    def save_raster(data, output_fn, reference_fn, dtype=None, nodata=None):
+        """
+        Save a numpy array as a GeoTIFF using a reference raster's profile.
+
+        Parameters
+        ----------
+        data : numpy.ndarray
+            Data array to save
+        output_fn : str
+            Output file path
+        reference_fn : str
+            Reference raster file to copy metadata from
+        dtype : numpy.dtype or str, optional
+            Data type for output raster, default is None (uses float32)
+        nodata : int or float, optional
+            No-data value for output raster, default is None (uses reference nodata)
+
+        Returns
+        -------
+        None
+
+        Notes
+        -----
+        Copies CRS, transform, and other metadata from the reference raster.
+        Useful for saving processed data that should align with an existing raster.
+
+        Examples
+        --------
+        >>> diff = raster1.data - raster2.data
+        >>> Raster.save_raster(diff, "difference.tif", reference_fn="raster2.tif")
+        """
+        with rio.open(reference_fn) as ref_ds:
+            profile = ref_ds.profile.copy()
+            profile.update(count=1)
+
+            # Set dtype
+            if dtype is None:
+                dtype = rio.float32
+            profile.update(dtype=dtype)
+
+            # Set nodata
+            if nodata is not None:
+                profile.update(nodata=nodata)
+
+            with rio.open(output_fn, "w", **profile) as dst:
+                dst.write(data.astype(profile["dtype"]), 1)
+
+    @staticmethod
+    def load_and_diff_rasters(first_fn, second_fn):
+        """
+        Load two rasters, align them, and compute their difference.
+
+        Parameters
+        ----------
+        first_fn : str
+            Path to the first raster file
+        second_fn : str
+            Path to the second raster file (used as reference grid)
+
+        Returns
+        -------
+        numpy.ma.MaskedArray
+            Difference array (second_raster - first_raster)
+
+        Notes
+        -----
+        The first raster is reprojected and resampled to match the second raster's
+        grid before differencing. This replaces geoutils.raster.load_multiple_rasters.
+        """
+        raster_paths = [first_fn, second_fn]
+        ref_fn = second_fn
+
+        # Open reference raster to get target grid
+        with rio.open(ref_fn) as ref_ds:
+            ref_crs = ref_ds.crs
+            ref_transform = ref_ds.transform
+            ref_width = ref_ds.width
+            ref_height = ref_ds.height
+
+        # Load both rasters, reprojecting to reference grid
+        rasters_data = []
+        for fn in raster_paths:
+            with rio.open(fn) as src:
+                # If same CRS and bounds, just read directly
+                if (
+                    src.crs == ref_crs
+                    and src.transform == ref_transform
+                    and src.width == ref_width
+                    and src.height == ref_height
+                ):
+                    data = src.read(1, masked=True)
+                else:
+                    # Reproject to match reference grid
+                    data = np.empty((ref_height, ref_width), dtype=src.dtypes[0])
+                    rio.warp.reproject(
+                        source=rio.band(src, 1),
+                        destination=data,
+                        src_transform=src.transform,
+                        src_crs=src.crs,
+                        dst_transform=ref_transform,
+                        dst_crs=ref_crs,
+                        resampling=rio.warp.Resampling.bilinear,
+                    )
+                    # Convert to masked array with nodata
+                    nodata = src.nodata
+                    if nodata is not None:
+                        data = np.ma.masked_equal(data, nodata)
+                    else:
+                        data = np.ma.array(data)
+
+                rasters_data.append(data)
+
+        # Compute difference: second - first
+        diff = rasters_data[1] - rasters_data[0]
+        return diff
 
 
 class Plotter:

--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - pip
   - numpy
   - rasterio
+  - rioxarray
   - matplotlib
   - fiona
   - pandas
@@ -17,8 +18,6 @@ dependencies:
   - contextily
   - matplotlib-scalebar
   - click
-  - geoutils>=0.1.9
-  - xdem
   - sliderule
   - pip:
     - markdown-pdf


### PR DESCRIPTION
Resolves #4 

Resolves #80 

Related to #64 

The `xdem` and `geoutils` dependencies were used during early development. However, the code has evolved and these packages can be dropped as dependencies with their limited functionality moved into small functions built on fundamental geospatial packages (i.e. `rasterio`). While `xdem` and `geoutils` contain lots of excellent functions, they are overkill for this light-weight project. 