### PR TITLE
Read ESA WorldCover anonymously so SSO AWS configs don't crash reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.2] - 2026-06-11
+
+### Fixed
+- **ESA WorldCover sampling crashed on machines configured with AWS SSO/login.** `_sample_worldcover_into_gdf()` opened the public ESA WorldCover S3 COGs with rasterio's default AWS session, which eagerly resolves credentials. On a machine whose `~/.aws/config` uses an SSO/login provider, botocore raised `MissingDependencyException: Using the login credential provider requires an additional dependency ... botocore[crt]`, aborting the entire `asp_plot` report even though the bucket is public and needs no credentials. The reads now use an explicit unsigned session (`rasterio.session.AWSSession(aws_unsigned=True)`), so anonymous access is used regardless of the user's AWS configuration.
+
 ## [1.15.1] - 2026-06-10
 
 ### Fixed

--- a/asp_plot/altimetry.py
+++ b/asp_plot/altimetry.py
@@ -749,10 +749,19 @@ class Altimetry:
         """
         import rasterio
         from rasterio.errors import RasterioIOError
+        from rasterio.session import AWSSession
 
         wc_col = "esa_worldcover.value"
         if wc_col in atl06sr.columns:
             return atl06sr
+
+        # The ESA WorldCover bucket is public, so read it anonymously
+        # (aws_unsigned=True). Without this, rasterio creates a default
+        # AWSSession that eagerly resolves credentials; on machines configured
+        # with AWS SSO/login this raises botocore MissingDependencyException
+        # ("requires botocore[crt]") and the whole report crashes — even though
+        # no credentials are needed for a public bucket.
+        unsigned_session = AWSSession(aws_unsigned=True)
 
         gdf_4326 = atl06sr.to_crs("EPSG:4326")
         lons = gdf_4326.geometry.x.values
@@ -771,6 +780,7 @@ class Altimetry:
         for url in tile_keys:
             try:
                 with rasterio.Env(
+                    unsigned_session,
                     GDAL_DISABLE_READDIR_ON_OPEN="YES",
                     CPL_VSIL_CURL_USE_HEAD="NO",
                 ):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asp_plot"
-version = "1.15.1"
+version = "1.15.2"
 license = {text = "BSD-3-Clause"}
 authors = [
   { name="Ben Purinton", email="purinton@uw.edu" },


### PR DESCRIPTION
## Summary

`Altimetry._sample_worldcover_into_gdf()` reads the **public** ESA WorldCover 10 m COGs from S3, but opened them with rasterio's default AWS session, which eagerly resolves AWS credentials. On a machine whose `~/.aws/config` uses an SSO/login provider, botocore raises:

```
botocore.exceptions.MissingDependencyException: Missing Dependency:
Using the login credential provider requires an additional dependency.
You will need to pip install "botocore[crt]" before proceeding.
```

…which aborts the **entire** `asp_plot` report during the ICESat-2 WorldCover landcover step — even though the bucket is public and needs no credentials at all.

## Fix

Open the COGs with an explicit unsigned session:

```python
from rasterio.session import AWSSession
unsigned_session = AWSSession(aws_unsigned=True)
with rasterio.Env(unsigned_session, GDAL_DISABLE_READDIR_ON_OPEN="YES", CPL_VSIL_CURL_USE_HEAD="NO"):
    with rasterio.open(url) as src:
        ...
```

`aws_unsigned=True` skips credential resolution entirely, so anonymous access is used regardless of the user's AWS configuration.

## Verification

Reproduced and fixed against the offending machine config (no env-var workarounds):

```
CURRENT: crashed -> MissingDependencyException  (login credential provider ... botocore[crt])
FIX:     opened OK, bounds: (-120.0, 30.0, -117.0, 33.0)
```

This surfaced while validating #121's `--reuse_selections` on a real Earth (ASTER) example; users currently work around it with `AWS_NO_SIGN_REQUEST=YES AWS_CONFIG_FILE=/dev/null`, which this fix makes unnecessary.

## Notes

- Bumps version **1.15.1 → 1.15.2** (patch). This is independent of #121. **If #121 (which bumps to 1.16.0) merges first, this branch needs a quick rebump to 1.16.1** to stay ahead — happy to rebase whenever you sequence them.
- No new dependency: `rasterio.session.AWSSession` is already available via the existing rasterio dependency.
