### PR TITLE
Introduce a single Body abstraction for Earth/Moon/Mars facts (#126)

### DIFF
--- a/asp_plot/alignment.py
+++ b/asp_plot/alignment.py
@@ -5,23 +5,13 @@ import re
 import numpy as np
 from osgeo import gdal, osr
 
+from asp_plot.bodies import BODIES
 from asp_plot.utils import (
     Raster,
     detect_planetary_body,
     glob_file,
     run_subprocess_command,
 )
-
-# Body-centered geocentric ("ECEF-equivalent") CRS for each supported
-# planet. Used by apply_dem_translation to convert pc_align's Cartesian
-# translation vector into the DEM's projected coordinate system. The
-# Earth case is keyed via EPSG; planets need a PROJ string because PROJ
-# refuses to operate across celestial bodies.
-_GEOCENTRIC_PROJ = {
-    "earth": None,  # use EPSG:4978
-    "moon": "+proj=geocent +R=1737400 +units=m +no_defs",
-    "mars": "+proj=geocent +R=3396190 +units=m +no_defs",
-}
 
 logging.basicConfig(level=logging.WARNING)
 logger = logging.getLogger(__name__)
@@ -195,7 +185,7 @@ class Alignment:
                 "Use Altimetry.to_csv_for_pc_align_planetary() to create it.\n"
             )
 
-        datum = {"moon": "D_MOON", "mars": "D_MARS"}.get(body)
+        datum = BODIES[body].datum if body in BODIES else None
         if datum is None:
             raise ValueError(
                 f"Unsupported body for pc_align_dem_to_planetary_csv: {body}"
@@ -384,7 +374,7 @@ class Alignment:
         # Mars/Moon and EPSG:4978 for Earth.
         body = detect_planetary_body(self.dem_fn)
         ecef_srs = osr.SpatialReference()
-        proj_string = _GEOCENTRIC_PROJ.get(body)
+        proj_string = BODIES[body].geocentric_proj
         if proj_string is None:
             ecef_srs.ImportFromEPSG(4978)
         else:

--- a/asp_plot/altimetry.py
+++ b/asp_plot/altimetry.py
@@ -17,6 +17,7 @@ from rasterio import plot as rioplot
 from sliderule import sliderule as sliderule_api
 
 from asp_plot.alignment import Alignment
+from asp_plot.bodies import BODIES
 from asp_plot.stereopair_metadata_parser import StereopairMetadataParser
 from asp_plot.utils import ColorBar, Raster, glob_file, save_figure
 
@@ -25,10 +26,11 @@ logger = logging.getLogger(__name__)
 
 ICESAT2_MISSION_START = datetime(2018, 10, 14, tzinfo=timezone.utc)
 
-# IAU 2000 mean equatorial radii used by ASP DEMs and pc_align.
-# ASP DEM heights are stored as (planetary_radius - sphere_radius).
-MARS_IAU_SPHERE_RADIUS = 3_396_190.0  # meters
-MOON_IAU_SPHERE_RADIUS = 1_737_400.0  # meters
+# IAU 2000 mean equatorial radii used by ASP DEMs and pc_align (stored as
+# (planetary_radius - sphere_radius)). Sourced from the body registry so the
+# values live in exactly one place.
+MARS_IAU_SPHERE_RADIUS = BODIES["mars"].iau_sphere_radius_m  # meters
+MOON_IAU_SPHERE_RADIUS = BODIES["moon"].iau_sphere_radius_m  # meters
 
 WORLDCOVER_NAMES = {
     10: "Tree cover",
@@ -1503,9 +1505,10 @@ class Altimetry:
         "radius",
     ]
 
-    # Geographic CRS WKT strings for building GeoDataFrames
-    _MOON_GEO_CRS = 'GEOGCRS["Moon",DATUM["D_MOON",ELLIPSOID["MOON",1737400,0]],PRIMEM["Reference_Meridian",0],CS[ellipsoidal,2],AXIS["latitude",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["longitude",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]]]'
-    _MARS_GEO_CRS = 'GEOGCRS["Mars",DATUM["D_MARS",ELLIPSOID["MARS",3396190,0]],PRIMEM["Reference_Meridian",0],CS[ellipsoidal,2],AXIS["latitude",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["longitude",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]]]'
+    # Geographic CRS WKT strings for building GeoDataFrames (sourced from the
+    # body registry).
+    _MOON_GEO_CRS = BODIES["moon"].geographic_crs_wkt
+    _MARS_GEO_CRS = BODIES["mars"].geographic_crs_wkt
 
     @staticmethod
     def _find_csv_column(cols_lower, candidates):
@@ -1854,7 +1857,7 @@ class Altimetry:
         from asp_plot.utils import detect_planetary_body
 
         body = detect_planetary_body(self.dem_fn)
-        instrument = {"moon": "LOLA", "mars": "MOLA"}.get(body, "Altimetry")
+        instrument = BODIES[body].altimetry_instrument
 
         parameters_used = {
             "max_displacement": max_displacement,
@@ -2042,7 +2045,7 @@ class Altimetry:
             self.planetary_to_dem_dh()
 
         body = detect_planetary_body(self.dem_fn)
-        instrument = {"moon": "LOLA", "mars": "MOLA"}.get(body, "Altimetry")
+        instrument = BODIES[body].altimetry_instrument
         if title is None:
             title = f"{instrument} vs DEM"
 
@@ -2161,7 +2164,7 @@ class Altimetry:
             return
 
         body = detect_planetary_body(self.dem_fn)
-        instrument = {"moon": "LOLA", "mars": "MOLA"}.get(body, "Altimetry")
+        instrument = BODIES[body].altimetry_instrument
         if title is None:
             title = f"{instrument} vs ASP DEM"
 

--- a/asp_plot/bodies.py
+++ b/asp_plot/bodies.py
@@ -1,0 +1,124 @@
+"""Per-body facts for the planetary bodies asp_plot supports.
+
+Earth, the Moon, and Mars each carry a handful of constants that the rest of
+the package needs: an altimetry instrument name, an IAU sphere radius, a
+``pc_align --datum`` string, a geocentric PROJ string, and a geographic CRS
+WKT.  Historically these were re-typed as ad-hoc ``{"moon": ..., "mars": ...}``
+dict literals at every use site.  This module collects them into one frozen
+:class:`Body` dataclass and a :data:`BODIES` registry so that adding a body (or
+correcting a constant) is a single-line change rather than a grep across files.
+
+The canonical body *detector* remains :func:`asp_plot.utils.detect_planetary_body`,
+which inspects a DEM's CRS WKT.  :func:`body_for_dem` wraps it to return the
+matching :class:`Body`.
+"""
+
+from dataclasses import dataclass
+
+# Geographic CRS WKT strings for building planetary GeoDataFrames. Kept as
+# module constants so the (long) WKT lives in exactly one place.
+_MOON_GEO_CRS = 'GEOGCRS["Moon",DATUM["D_MOON",ELLIPSOID["MOON",1737400,0]],PRIMEM["Reference_Meridian",0],CS[ellipsoidal,2],AXIS["latitude",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["longitude",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]]]'
+_MARS_GEO_CRS = 'GEOGCRS["Mars",DATUM["D_MARS",ELLIPSOID["MARS",3396190,0]],PRIMEM["Reference_Meridian",0],CS[ellipsoidal,2],AXIS["latitude",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["longitude",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]]]'
+
+
+@dataclass(frozen=True)
+class Body:
+    """Immutable bundle of per-body facts.
+
+    Attributes
+    ----------
+    name : str
+        Canonical body name: ``"earth"``, ``"moon"``, or ``"mars"``.  Matches
+        the strings returned by :func:`asp_plot.utils.detect_planetary_body`.
+    altimetry_instrument : str
+        Reference altimetry instrument: ``"ICESat-2"``, ``"LOLA"``, or
+        ``"MOLA"``.
+    iau_sphere_radius_m : float or None
+        IAU mean sphere radius in meters, used to convert planetary radius to
+        height above the sphere.  ``None`` for Earth, which uses an ellipsoid
+        rather than a sphere.
+    datum : str or None
+        ASP ``pc_align --datum`` string (``"D_MOON"`` / ``"D_MARS"``).
+        ``None`` for Earth (pc_align infers the datum from the data).
+    geocentric_proj : str or None
+        Body-centered geocentric ("ECEF-equivalent") PROJ string used to
+        convert a Cartesian translation vector into the DEM's CRS.  ``None``
+        for Earth, where ``EPSG:4978`` is used instead (PROJ refuses to
+        operate across celestial bodies, so planets need an explicit string).
+    geographic_crs_wkt : str or None
+        Geographic CRS WKT used when building planetary GeoDataFrames.
+        ``None`` for Earth, whose data already carry a CRS.
+    semi_major_axis_m : float
+        Ellipsoid semi-major axis in meters (fallback for building a
+        geographic CRS when a DEM's own ellipsoid is unavailable).
+    inverse_flattening : float
+        Ellipsoid inverse flattening (``0.0`` for the spherical bodies).
+    """
+
+    name: str
+    altimetry_instrument: str
+    iau_sphere_radius_m: "float | None"
+    datum: "str | None"
+    geocentric_proj: "str | None"
+    geographic_crs_wkt: "str | None"
+    semi_major_axis_m: float
+    inverse_flattening: float
+
+
+BODIES = {
+    "earth": Body(
+        name="earth",
+        altimetry_instrument="ICESat-2",
+        iau_sphere_radius_m=None,
+        datum=None,
+        geocentric_proj=None,  # use EPSG:4978
+        geographic_crs_wkt=None,
+        semi_major_axis_m=6378137.0,
+        inverse_flattening=298.257223563,
+    ),
+    "moon": Body(
+        name="moon",
+        altimetry_instrument="LOLA",
+        iau_sphere_radius_m=1_737_400.0,
+        datum="D_MOON",
+        geocentric_proj="+proj=geocent +R=1737400 +units=m +no_defs",
+        geographic_crs_wkt=_MOON_GEO_CRS,
+        semi_major_axis_m=1_737_400.0,
+        inverse_flattening=0.0,
+    ),
+    "mars": Body(
+        name="mars",
+        altimetry_instrument="MOLA",
+        iau_sphere_radius_m=3_396_190.0,
+        datum="D_MARS",
+        geocentric_proj="+proj=geocent +R=3396190 +units=m +no_defs",
+        geographic_crs_wkt=_MARS_GEO_CRS,
+        semi_major_axis_m=3_396_190.0,
+        inverse_flattening=0.0,
+    ),
+}
+
+
+def body_for_dem(dem_fn, body=None):
+    """Return the :class:`Body` for a DEM.
+
+    Parameters
+    ----------
+    dem_fn : str
+        Path to the DEM file.
+    body : str or None, optional
+        Body name to look up directly.  If ``None`` (default), the body is
+        auto-detected from the DEM's CRS via
+        :func:`asp_plot.utils.detect_planetary_body`.
+
+    Returns
+    -------
+    Body
+    """
+    # Imported lazily to avoid a circular import (utils imports nothing from
+    # here, but keeping the import local keeps this module dependency-light).
+    from asp_plot.utils import detect_planetary_body
+
+    if body is None:
+        body = detect_planetary_body(dem_fn)
+    return BODIES[body]

--- a/asp_plot/cli/asp_plot.py
+++ b/asp_plot/cli/asp_plot.py
@@ -7,6 +7,7 @@ import click
 import contextily as ctx
 
 from asp_plot.altimetry import Altimetry
+from asp_plot.bodies import BODIES
 from asp_plot.bundle_adjust import PlotBundleAdjustFiles, ReadBundleAdjustFiles
 from asp_plot.processing_parameters import ProcessingParameters
 from asp_plot.report import (
@@ -804,7 +805,7 @@ def main(
                     )
 
         elif body in ("moon", "mars"):
-            instrument = {"moon": "LOLA", "mars": "MOLA"}[body]
+            instrument = BODIES[body].altimetry_instrument
 
             if not altimetry_csv:
                 print(

--- a/asp_plot/utils.py
+++ b/asp_plot/utils.py
@@ -250,13 +250,12 @@ def get_planetary_bounds(dem_fn, body=None):
         semi_major = ellipsoid.semi_major_metre
         inv_flat = ellipsoid.inverse_flattening
     else:
-        # Fallback values for known bodies
-        _body_radii = {
-            "moon": (1737400.0, 0.0),
-            "mars": (3396190.0, 0.0),
-            "earth": (6378137.0, 298.257223563),
-        }
-        semi_major, inv_flat = _body_radii.get(body, (6378137.0, 298.257223563))
+        # Fallback values for known bodies, sourced from the body registry.
+        from asp_plot.bodies import BODIES
+
+        fallback = BODIES.get(body, BODIES["earth"])
+        semi_major = fallback.semi_major_axis_m
+        inv_flat = fallback.inverse_flattening
 
     # Construct a geographic CRS from the ellipsoid parameters
     geo_crs = CRS.from_json_dict(

--- a/tests/test_altimetry.py
+++ b/tests/test_altimetry.py
@@ -408,6 +408,38 @@ class TestPlanetaryDh:
         except Exception as e:
             pytest.fail(f"histogram_planetary_to_dem raised: {e}")
 
+    @pytest.mark.parametrize(
+        "body, instrument",
+        [("moon", "LOLA"), ("mars", "MOLA")],
+    )
+    def test_planetary_plot_titles_use_body_instrument(
+        self, alt_with_points, monkeypatch, body, instrument
+    ):
+        """The planetary plot/histogram titles must reflect the body's
+        altimetry instrument (LOLA for the Moon, MOLA for Mars), sourced
+        from the Body registry.
+
+        The fixture DEM is an Earth DEM, so detection is stubbed to the
+        planetary body to exercise the real moon/mars labeling path that
+        the Earth-DEM fixtures otherwise never reach.
+        """
+        import matplotlib.pyplot as plt
+
+        import asp_plot.utils
+
+        monkeypatch.setattr(
+            asp_plot.utils, "detect_planetary_body", lambda dem_fn: body
+        )
+        alt_with_points.planetary_to_dem_dh()
+
+        plt.close("all")
+        alt_with_points.mapview_plot_planetary_to_dem()
+        assert plt.gcf()._suptitle.get_text() == f"{instrument} vs DEM"
+
+        plt.close("all")
+        alt_with_points.histogram_planetary_to_dem()
+        assert plt.gcf()._suptitle.get_text() == f"{instrument} vs ASP DEM"
+
     def test_to_csv_for_pc_align_planetary(self, alt_with_points, tmp_path):
         """to_csv_for_pc_align_planetary writes lon/lat/radius_m only."""
         # Add the radius_m column the loaders normally populate

--- a/tests/test_bodies.py
+++ b/tests/test_bodies.py
@@ -51,3 +51,20 @@ class TestBodyForDem:
         assert body_for_dem("unused.tif", body="mars") is BODIES["mars"]
         assert body_for_dem("unused.tif", body="moon") is BODIES["moon"]
         assert body_for_dem("unused.tif", body="earth") is BODIES["earth"]
+
+    def test_autodetects_from_dem_crs(self):
+        # With body=None, body_for_dem must route through
+        # detect_planetary_body, which reads the DEM CRS. The Earth test DEM
+        # is the only real DEM in the fixtures, so it exercises the
+        # auto-detection branch end to end.
+        dem = "tests/test_data/stereo/date_time_left_right_1m-DEM.tif"
+        assert body_for_dem(dem) is BODIES["earth"]
+
+    def test_autodetection_uses_detect_planetary_body(self, monkeypatch):
+        # Pin the wiring: a stubbed detector return is what selects the Body.
+        import asp_plot.utils
+
+        monkeypatch.setattr(
+            asp_plot.utils, "detect_planetary_body", lambda dem_fn: "mars"
+        )
+        assert body_for_dem("anything.tif") is BODIES["mars"]

--- a/tests/test_bodies.py
+++ b/tests/test_bodies.py
@@ -1,0 +1,53 @@
+import pytest
+
+from asp_plot.bodies import BODIES, Body, body_for_dem
+
+
+class TestBodyRegistry:
+    def test_registry_keys(self):
+        assert set(BODIES) == {"earth", "moon", "mars"}
+
+    def test_entries_are_frozen_body_instances(self):
+        for name, body in BODIES.items():
+            assert isinstance(body, Body)
+            assert body.name == name
+            with pytest.raises(Exception):
+                body.name = "changed"  # frozen dataclass
+
+    def test_earth_facts(self):
+        earth = BODIES["earth"]
+        assert earth.altimetry_instrument == "ICESat-2"
+        assert earth.iau_sphere_radius_m is None
+        assert earth.datum is None
+        assert earth.geocentric_proj is None  # EPSG:4978 used instead
+        assert earth.geographic_crs_wkt is None
+        assert earth.semi_major_axis_m == 6378137.0
+        assert earth.inverse_flattening == pytest.approx(298.257223563)
+
+    def test_moon_facts(self):
+        moon = BODIES["moon"]
+        assert moon.altimetry_instrument == "LOLA"
+        assert moon.iau_sphere_radius_m == 1_737_400.0
+        assert moon.datum == "D_MOON"
+        assert moon.geocentric_proj == "+proj=geocent +R=1737400 +units=m +no_defs"
+        assert "D_MOON" in moon.geographic_crs_wkt
+        assert moon.semi_major_axis_m == 1_737_400.0
+        assert moon.inverse_flattening == 0.0
+
+    def test_mars_facts(self):
+        mars = BODIES["mars"]
+        assert mars.altimetry_instrument == "MOLA"
+        assert mars.iau_sphere_radius_m == 3_396_190.0
+        assert mars.datum == "D_MARS"
+        assert mars.geocentric_proj == "+proj=geocent +R=3396190 +units=m +no_defs"
+        assert "D_MARS" in mars.geographic_crs_wkt
+        assert mars.semi_major_axis_m == 3_396_190.0
+        assert mars.inverse_flattening == 0.0
+
+
+class TestBodyForDem:
+    def test_explicit_body_skips_detection(self):
+        # Passing body= avoids any DEM read and returns the registry entry.
+        assert body_for_dem("unused.tif", body="mars") is BODIES["mars"]
+        assert body_for_dem("unused.tif", body="moon") is BODIES["moon"]
+        assert body_for_dem("unused.tif", body="earth") is BODIES["earth"]

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -13,6 +13,7 @@ class TestImports:
     def test_import_asp_plot_modules(self):
         import asp_plot.alignment
         import asp_plot.altimetry
+        import asp_plot.bodies
         import asp_plot.bundle_adjust
         import asp_plot.csm_camera
         import asp_plot.gallery
@@ -34,10 +35,12 @@ class TestImports:
         assert asp_plot.bundle_adjust is not None
         assert asp_plot.altimetry is not None
         assert asp_plot.alignment is not None
+        assert asp_plot.bodies is not None
 
     def test_import_asp_plot_classes(self):
         from asp_plot.alignment import Alignment
         from asp_plot.altimetry import Altimetry
+        from asp_plot.bodies import BODIES, Body, body_for_dem
         from asp_plot.bundle_adjust import PlotBundleAdjustFiles, ReadBundleAdjustFiles
         from asp_plot.gallery import GalleryPlotter
         from asp_plot.processing_parameters import ProcessingParameters
@@ -62,3 +65,6 @@ class TestImports:
         assert StereoPlotter is not None
         assert Altimetry is not None
         assert Alignment is not None
+        assert Body is not None
+        assert BODIES is not None
+        assert body_for_dem is not None


### PR DESCRIPTION
Closes #126. First step of the structural rewrite tracked in #122.

## What

Adds `asp_plot/bodies.py` with a frozen `Body` dataclass, a `BODIES` registry (`earth`/`moon`/`mars`), and a `body_for_dem()` helper. Each body now owns its facts in one place:

| Field | earth | moon | mars |
|---|---|---|---|
| `altimetry_instrument` | ICESat-2 | LOLA | MOLA |
| `iau_sphere_radius_m` | None | 1 737 400 | 3 396 190 |
| `datum` | None | D_MOON | D_MARS |
| `geocentric_proj` | None (EPSG:4978) | `+proj=geocent +R=1737400 …` | `+proj=geocent +R=3396190 …` |
| `geographic_crs_wkt` | None | `GEOGCRS["Moon"…]` | `GEOGCRS["Mars"…]` |
| `semi_major_axis_m` / `inverse_flattening` | 6378137 / 298.257 | 1737400 / 0 | 3396190 / 0 |

## Why

The Earth-vs-Moon-vs-Mars facts were re-typed as ad-hoc `{"moon": ..., "mars": ...}` dict literals and scattered module/class constants across 5 files. This consolidates them so adding a body (or fixing a constant) is a one-line table edit, and unblocks the downstream refactors (#127 pc_align collapse, #130 altimetry split).

## Replaced literals/constants with `body.attr` accesses
- `alignment.py` — `_GEOCENTRIC_PROJ` table + the `{moon/mars → D_MOON/D_MARS}` datum literal
- `altimetry.py` — `MARS_/MOON_IAU_SPHERE_RADIUS`, `_MOON_/_MARS_GEO_CRS`, and the three `{moon: LOLA, mars: MOLA}` instrument literals
- `cli/asp_plot.py` — the instrument literal
- `utils.py` — the `get_planetary_bounds` fallback-radii dict

## Behavior

Pure internal refactor, no user-visible change. The CRS WKT / PROJ / radius / datum strings are byte-for-byte the same values, now sourced from the registry.

## Tests

- New `tests/test_bodies.py` pins every registry value and `body_for_dem()`.
- `tests/test_imports.py` extended to cover the new module/symbols.
- Full suite green locally: **194 passed**. pre-commit (black/flake8/isort) clean.

## Acceptance criteria (from #126)
- [x] `bodies.py` with `Body` dataclass + `BODIES` registry + `body_for_dem()`
- [x] All `{"moon": ..., "mars": ...}` dict literals removed in `altimetry.py` and `alignment.py`
- [x] Module-level radius/CRS/datum constants consolidated into the registry
- [x] Existing test suite green; no behavior change