### PR TITLE
Collapse duplicated pc_align + alignment-evaluation code paths (#127)

### DIFF
--- a/asp_plot/alignment.py
+++ b/asp_plot/alignment.py
@@ -115,10 +115,62 @@ class Alignment:
                 f"\nATL06 filtered CSV file not found: {atl06sr_csv}\nWe need this to run pc_align. It can be created with the to_csv_for_pc_align() function in the Altimetry module.\n"
             )
 
+        self._run_pc_align(
+            csv=atl06sr_csv,
+            csv_format="1:lon 2:lat 3:height_above_datum",
+            max_displacement=max_displacement,
+            max_source_points=max_source_points,
+            alignment_method=alignment_method,
+            output_prefix=output_prefix,
+        )
+
+    def _run_pc_align(
+        self,
+        csv,
+        csv_format,
+        max_displacement,
+        datum=None,
+        max_source_points=10000000,
+        alignment_method="point-to-point",
+        output_prefix="pc_align/pc_align",
+    ):
+        """Run ASP ``pc_align`` to align ``self.dem_fn`` to a reference CSV.
+
+        Backs both :meth:`pc_align_dem_to_atl06sr` (ICESat-2) and
+        :meth:`pc_align_dem_to_planetary_csv` (LOLA/MOLA). The two paths
+        differ only in ``csv_format``, the optional ``--datum`` flag, and the
+        default ``max_displacement``; the rest of the ``pc_align`` argv is
+        identical, so it lives here once.
+
+        Parameters
+        ----------
+        csv : str
+            Path to the reference CSV. The caller is responsible for
+            validating that it exists.
+        csv_format : str
+            ASP ``--csv-format`` string describing the lon/lat/height columns.
+        max_displacement : float
+            ``--max-displacement`` in meters.
+        datum : str or None, optional
+            ASP ``--datum`` flag (e.g. ``"D_MOON"``/``"D_MARS"``). Omitted
+            from the command when None (the ICESat-2/Earth path).
+        max_source_points : int, optional
+            ``--max-num-source-points``. Default 10,000,000.
+        alignment_method : str, optional
+            ``--alignment-method``. Default ``"point-to-point"``.
+        output_prefix : str, optional
+            Output prefix relative to ``self.directory``.
+        """
         pc_align_folder = os.path.join(self.directory, output_prefix)
 
+        datum_note = (
+            f"\n  --datum {datum}, --max-displacement {max_displacement}"
+            if datum is not None
+            else ""
+        )
         print(
-            f"Running pc_align on {self.dem_fn} and {atl06sr_csv}\nWriting to {pc_align_folder}*"
+            f"Running pc_align on {self.dem_fn} and {csv}{datum_note}\n"
+            f"Writing to {pc_align_folder}*"
         )
 
         command = [
@@ -130,12 +182,16 @@ class Alignment:
             "--alignment-method",
             alignment_method,
             "--csv-format",
-            "1:lon 2:lat 3:height_above_datum",
+            csv_format,
+        ]
+        if datum is not None:
+            command += ["--datum", datum]
+        command += [
             "--compute-translation-only",
             "--output-prefix",
             pc_align_folder,
             self.dem_fn,
-            atl06sr_csv,
+            csv,
         ]
 
         run_subprocess_command(command)
@@ -191,34 +247,15 @@ class Alignment:
                 f"Unsupported body for pc_align_dem_to_planetary_csv: {body}"
             )
 
-        pc_align_folder = os.path.join(self.directory, output_prefix)
-
-        print(
-            f"Running pc_align on {self.dem_fn} and {planetary_csv}\n"
-            f"  --datum {datum}, --max-displacement {max_displacement}\n"
-            f"Writing to {pc_align_folder}*"
+        self._run_pc_align(
+            csv=planetary_csv,
+            csv_format="1:lon 2:lat 3:radius_m",
+            max_displacement=max_displacement,
+            datum=datum,
+            max_source_points=max_source_points,
+            alignment_method=alignment_method,
+            output_prefix=output_prefix,
         )
-
-        command = [
-            "pc_align",
-            "--max-displacement",
-            str(max_displacement),
-            "--max-num-source-points",
-            str(max_source_points),
-            "--alignment-method",
-            alignment_method,
-            "--csv-format",
-            "1:lon 2:lat 3:radius_m",
-            "--datum",
-            datum,
-            "--compute-translation-only",
-            "--output-prefix",
-            pc_align_folder,
-            self.dem_fn,
-            planetary_csv,
-        ]
-
-        run_subprocess_command(command)
 
     def pc_align_report(self, output_prefix="pc_align/pc_align"):
         """

--- a/asp_plot/altimetry.py
+++ b/asp_plot/altimetry.py
@@ -1370,10 +1370,7 @@ class Altimetry:
         row = df.iloc[0]
         p50_beg = float(row.get("p50_beg", float("nan")))
         p50_end = float(row.get("p50_end", float("nan")))
-        if not np.isfinite(p50_beg) or not np.isfinite(p50_end) or p50_beg == 0:
-            improvement_pct = None
-        else:
-            improvement_pct = (p50_beg - p50_end) / p50_beg * 100.0
+        improvement_pct = self._improvement_pct(p50_beg, p50_end)
 
         # alignment_report may decline to write the aligned DEM if the
         # translation magnitude is under min_translation_threshold × GSD
@@ -1382,40 +1379,38 @@ class Altimetry:
         # that as no_improvement even if p50 happened to drop > threshold.
         translation_too_small = self.aligned_dem_fn is None
 
+        improvement_repr = (
+            f"{improvement_pct:.1f}%" if improvement_pct is not None else "n/a"
+        )
         if (
-            improvement_pct is None
-            or p50_end >= p50_beg
-            or improvement_pct <= improvement_threshold_pct
-            or translation_too_small
+            translation_too_small
+            and improvement_pct is not None
+            and (p50_end < p50_beg and improvement_pct > improvement_threshold_pct)
         ):
-            self._remove_aligned_dem_if_present()
-            improvement_repr = (
-                f"{improvement_pct:.1f}%" if improvement_pct is not None else "n/a"
+            reason = (
+                f"Translation magnitude is below {min_translation_threshold*100:.0f}% "
+                "of the DEM GSD, so no aligned DEM was written despite a "
+                f"{improvement_repr} p50 reduction."
             )
-            if (
-                translation_too_small
-                and improvement_pct is not None
-                and (p50_end < p50_beg and improvement_pct > improvement_threshold_pct)
-            ):
-                reason = (
-                    f"Translation magnitude is below {min_translation_threshold*100:.0f}% "
-                    "of the DEM GSD, so no aligned DEM was written despite a "
-                    f"{improvement_repr} p50 reduction."
-                )
-            else:
-                reason = (
-                    f"p50 {p50_beg:.2f} m -> {p50_end:.2f} m, "
-                    f"{improvement_repr} <= {improvement_threshold_pct:.1f}% "
-                    "threshold. Aligned DEM removed."
-                )
-            return AlignmentResult(
-                status="no_improvement",
-                alignment_report_df=df,
-                aligned_dem_fn=None,
-                improvement_pct=improvement_pct,
-                message=f"No significant improvement: {reason}",
-                parameters_used=parameters_used,
+        else:
+            reason = (
+                f"p50 {p50_beg:.2f} m -> {p50_end:.2f} m, "
+                f"{improvement_repr} <= {improvement_threshold_pct:.1f}% "
+                "threshold. Aligned DEM removed."
             )
+
+        result = self._evaluate_improvement(
+            df=df,
+            p50_beg=p50_beg,
+            p50_end=p50_end,
+            improvement_pct=improvement_pct,
+            improvement_threshold_pct=improvement_threshold_pct,
+            translation_too_small=translation_too_small,
+            no_improvement_reason=reason,
+            parameters_used=parameters_used,
+        )
+        if result is not None:
+            return result
 
         # Populate icesat_minus_aligned_dem without re-running the 3σ
         # outlier filter (the unaligned column is already 3σ-clean from the
@@ -1424,17 +1419,8 @@ class Altimetry:
         # This does not re-request ICESat-2 data; it only interpolates DEM
         # heights at the existing ATL06-SR point locations.
         self.atl06sr_to_dem_dh(n_sigma=None)
-        return AlignmentResult(
-            status="success",
-            alignment_report_df=df,
-            aligned_dem_fn=self.aligned_dem_fn,
-            improvement_pct=improvement_pct,
-            message=(
-                f"p50 improved from {p50_beg:.2f} m -> {p50_end:.2f} m "
-                f"({improvement_pct:.1f}% reduction). Aligned DEM written to "
-                f"{self.aligned_dem_fn}."
-            ),
-            parameters_used=parameters_used,
+        return self._success_result(
+            df, p50_beg, p50_end, improvement_pct, parameters_used
         )
 
     def _remove_aligned_dem_if_present(self):
@@ -1450,6 +1436,89 @@ class Altimetry:
             except OSError as e:
                 logger.warning(f"\nCould not remove aligned DEM {aligned}: {e}\n")
         self.aligned_dem_fn = None
+
+    @staticmethod
+    def _improvement_pct(p50_beg, p50_end):
+        """Percent p50 reduction from alignment, or None if not computable.
+
+        ``(p50_beg - p50_end) / p50_beg * 100``. Returns None when either
+        value is non-finite or ``p50_beg`` is zero. Shared by the ICESat-2
+        and planetary align-and-evaluate paths.
+        """
+        if not np.isfinite(p50_beg) or not np.isfinite(p50_end) or p50_beg == 0:
+            return None
+        return (p50_beg - p50_end) / p50_beg * 100.0
+
+    def _evaluate_improvement(
+        self,
+        *,
+        df,
+        p50_beg,
+        p50_end,
+        improvement_pct,
+        improvement_threshold_pct,
+        translation_too_small,
+        no_improvement_reason,
+        parameters_used,
+    ):
+        """Shared keep/discard decision for ICESat-2 and planetary alignment.
+
+        Applies the common rejection predicate used by both
+        :meth:`align_and_evaluate` and :meth:`align_and_evaluate_planetary`:
+        the aligned DEM is discarded when the p50 improvement is missing,
+        non-positive, at or below ``improvement_threshold_pct``, or the
+        translation was too small to write a DEM.
+
+        Returns
+        -------
+        AlignmentResult or None
+            A terminal ``no_improvement`` result (with the aligned DEM
+            already cleaned up) when the alignment is rejected, or ``None``
+            when it should be kept. In the keep case the caller performs its
+            body-specific success finalization and builds the success result
+            via :meth:`_success_result`.
+
+        Notes
+        -----
+        ``no_improvement_reason`` is supplied by the caller because the
+        Earth and planetary paths word the rejection differently (GSD value,
+        translation wording). It is only consumed on the reject path.
+        """
+        if (
+            improvement_pct is None
+            or p50_end >= p50_beg
+            or improvement_pct <= improvement_threshold_pct
+            or translation_too_small
+        ):
+            self._remove_aligned_dem_if_present()
+            return AlignmentResult(
+                status="no_improvement",
+                alignment_report_df=df,
+                aligned_dem_fn=None,
+                improvement_pct=improvement_pct,
+                message=f"No significant improvement: {no_improvement_reason}",
+                parameters_used=parameters_used,
+            )
+        return None
+
+    def _success_result(self, df, p50_beg, p50_end, improvement_pct, parameters_used):
+        """Build the shared ``success`` AlignmentResult.
+
+        Identical for both bodies once the aligned DEM is retained on
+        ``self.aligned_dem_fn``.
+        """
+        return AlignmentResult(
+            status="success",
+            alignment_report_df=df,
+            aligned_dem_fn=self.aligned_dem_fn,
+            improvement_pct=improvement_pct,
+            message=(
+                f"p50 improved from {p50_beg:.2f} m -> {p50_end:.2f} m "
+                f"({improvement_pct:.1f}% reduction). Aligned DEM written to "
+                f"{self.aligned_dem_fn}."
+            ),
+            parameters_used=parameters_used,
+        )
 
     # ------------------------------------------------------------------ #
     #  Planetary altimetry: LOLA (Moon) and MOLA (Mars) via ODE GDS API  #
@@ -1935,41 +2004,36 @@ class Altimetry:
 
         p50_beg = float(report.get("p50_beg", float("nan")))
         p50_end = float(report.get("p50_end", float("nan")))
-        if not np.isfinite(p50_beg) or not np.isfinite(p50_end) or p50_beg == 0:
-            improvement_pct = None
-        else:
-            improvement_pct = (p50_beg - p50_end) / p50_beg * 100.0
+        improvement_pct = self._improvement_pct(p50_beg, p50_end)
 
-        if (
-            improvement_pct is None
-            or p50_end >= p50_beg
-            or improvement_pct <= improvement_threshold_pct
-            or translation_too_small
-        ):
-            self._remove_aligned_dem_if_present()
-            improvement_repr = (
-                f"{improvement_pct:.1f}%" if improvement_pct is not None else "n/a"
+        improvement_repr = (
+            f"{improvement_pct:.1f}%" if improvement_pct is not None else "n/a"
+        )
+        if translation_too_small:
+            reason = (
+                f"Translation magnitude is below {min_translation_threshold*100:.0f}% "
+                f"of the DEM GSD ({gsd:.2f} m), so no aligned DEM was "
+                f"written despite a {improvement_repr} p50 reduction."
             )
-            if translation_too_small:
-                reason = (
-                    f"Translation magnitude is below {min_translation_threshold*100:.0f}% "
-                    f"of the DEM GSD ({gsd:.2f} m), so no aligned DEM was "
-                    f"written despite a {improvement_repr} p50 reduction."
-                )
-            else:
-                reason = (
-                    f"p50 {p50_beg:.2f} m -> {p50_end:.2f} m, "
-                    f"{improvement_repr} <= {improvement_threshold_pct:.1f}% "
-                    "threshold."
-                )
-            return AlignmentResult(
-                status="no_improvement",
-                alignment_report_df=df,
-                aligned_dem_fn=None,
-                improvement_pct=improvement_pct,
-                message=f"No significant improvement: {reason}",
-                parameters_used=parameters_used,
+        else:
+            reason = (
+                f"p50 {p50_beg:.2f} m -> {p50_end:.2f} m, "
+                f"{improvement_repr} <= {improvement_threshold_pct:.1f}% "
+                "threshold."
             )
+
+        result = self._evaluate_improvement(
+            df=df,
+            p50_beg=p50_beg,
+            p50_end=p50_end,
+            improvement_pct=improvement_pct,
+            improvement_threshold_pct=improvement_threshold_pct,
+            translation_too_small=translation_too_small,
+            no_improvement_reason=reason,
+            parameters_used=parameters_used,
+        )
+        if result is not None:
+            return result
 
         # Apply the translation and persist the aligned DEM
         aligned = alignment.apply_dem_translation(output_prefix=output_prefix)
@@ -1992,17 +2056,8 @@ class Altimetry:
         # the already-clean sample again.
         self.planetary_to_dem_dh(n_sigma=None)
 
-        return AlignmentResult(
-            status="success",
-            alignment_report_df=df,
-            aligned_dem_fn=self.aligned_dem_fn,
-            improvement_pct=improvement_pct,
-            message=(
-                f"p50 improved from {p50_beg:.2f} m -> {p50_end:.2f} m "
-                f"({improvement_pct:.1f}% reduction). Aligned DEM written to "
-                f"{self.aligned_dem_fn}."
-            ),
-            parameters_used=parameters_used,
+        return self._success_result(
+            df, p50_beg, p50_end, improvement_pct, parameters_used
         )
 
     def mapview_plot_planetary_to_dem(

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -1,0 +1,104 @@
+import os
+
+import pytest
+
+from asp_plot.alignment import Alignment
+
+DEM = "tests/test_data/stereo/date_time_left_right_1m-DEM.tif"
+
+
+class TestRunPcAlign:
+    """The two public pc_align wrappers both delegate to _run_pc_align; the
+    argv they build must match the pre-refactor inline commands byte for byte.
+    """
+
+    @pytest.fixture
+    def captured(self, monkeypatch):
+        calls = {}
+        monkeypatch.setattr(
+            "asp_plot.alignment.run_subprocess_command",
+            lambda cmd: calls.__setitem__("cmd", cmd),
+        )
+        return calls
+
+    @pytest.fixture
+    def alignment(self, tmp_path):
+        return Alignment(directory=str(tmp_path), dem_fn=DEM)
+
+    def test_atl06sr_argv(self, alignment, captured, tmp_path):
+        csv = tmp_path / "atl.csv"
+        csv.write_text("x")
+        alignment.pc_align_dem_to_atl06sr(atl06sr_csv=str(csv))
+        assert captured["cmd"] == [
+            "pc_align",
+            "--max-displacement",
+            "20",
+            "--max-num-source-points",
+            "10000000",
+            "--alignment-method",
+            "point-to-point",
+            "--csv-format",
+            "1:lon 2:lat 3:height_above_datum",
+            "--compute-translation-only",
+            "--output-prefix",
+            os.path.join(str(tmp_path), "pc_align/pc_align"),
+            DEM,
+            str(csv),
+        ]
+        # The Earth/ICESat-2 path must not emit a --datum flag.
+        assert "--datum" not in captured["cmd"]
+
+    @pytest.mark.parametrize(
+        "body, datum",
+        [("moon", "D_MOON"), ("mars", "D_MARS")],
+    )
+    def test_planetary_argv(self, alignment, captured, tmp_path, body, datum):
+        csv = tmp_path / "planet.csv"
+        csv.write_text("x")
+        alignment.pc_align_dem_to_planetary_csv(planetary_csv=str(csv), body=body)
+        assert captured["cmd"] == [
+            "pc_align",
+            "--max-displacement",
+            "500",
+            "--max-num-source-points",
+            "10000000",
+            "--alignment-method",
+            "point-to-point",
+            "--csv-format",
+            "1:lon 2:lat 3:radius_m",
+            "--datum",
+            datum,
+            "--compute-translation-only",
+            "--output-prefix",
+            os.path.join(str(tmp_path), "pc_align/pc_align"),
+            DEM,
+            str(csv),
+        ]
+
+    def test_atl06sr_missing_csv_raises(self, alignment):
+        with pytest.raises(ValueError, match="not found"):
+            alignment.pc_align_dem_to_atl06sr(atl06sr_csv=None)
+
+    def test_planetary_missing_csv_raises(self, alignment, tmp_path):
+        with pytest.raises(ValueError, match="not found"):
+            alignment.pc_align_dem_to_planetary_csv(
+                planetary_csv=str(tmp_path / "missing.csv"), body="mars"
+            )
+
+    def test_planetary_rejects_earth(self, alignment, captured, tmp_path):
+        csv = tmp_path / "planet.csv"
+        csv.write_text("x")
+        with pytest.raises(ValueError, match="Unsupported body"):
+            alignment.pc_align_dem_to_planetary_csv(
+                planetary_csv=str(csv), body="earth"
+            )
+        # Rejected before any pc_align invocation.
+        assert "cmd" not in captured
+
+    def test_run_pc_align_max_displacement_passthrough(
+        self, alignment, captured, tmp_path
+    ):
+        csv = tmp_path / "atl.csv"
+        csv.write_text("x")
+        alignment.pc_align_dem_to_atl06sr(atl06sr_csv=str(csv), max_displacement=42)
+        assert captured["cmd"][captured["cmd"].index("--max-displacement") + 1] == "42"

--- a/tests/test_altimetry.py
+++ b/tests/test_altimetry.py
@@ -215,6 +215,35 @@ class TestAltimetry:
         assert result.aligned_dem_fn is None
         assert icesat.aligned_dem_fn is None
         assert not fake_aligned.exists(), "aligned DEM should be cleaned up"
+        # Pins the threshold-branch wording (Earth path appends "Aligned DEM
+        # removed."), which differs from the planetary path.
+        assert result.message == (
+            "No significant improvement: p50 2.00 m -> 2.00 m, 0.0% <= 5.0% "
+            "threshold. Aligned DEM removed."
+        )
+
+    def test_align_and_evaluate_translation_too_small(self, icesat, monkeypatch):
+        """A large p50 drop that is nonetheless not written (translation under
+        the GSD-fraction threshold, so alignment_report leaves aligned_dem_fn
+        None) is rejected with the translation-specific message."""
+
+        def fake_alignment_report(self, **kwargs):
+            self.aligned_dem_fn = None  # translation too small -> not written
+            self.alignment_report_df = pd.DataFrame(
+                [{"key": "all", "p50_beg": 2.0, "p50_end": 0.5}]
+            )
+
+        monkeypatch.setattr(Altimetry, "alignment_report", fake_alignment_report)
+        result = icesat.align_and_evaluate(
+            improvement_threshold_pct=5.0, min_translation_threshold=0.1
+        )
+        assert result.status == "no_improvement"
+        assert result.improvement_pct == pytest.approx(75.0)
+        assert result.message == (
+            "No significant improvement: Translation magnitude is below 10% of "
+            "the DEM GSD, so no aligned DEM was written despite a 75.0% p50 "
+            "reduction."
+        )
 
     def test_align_and_evaluate_success(self, icesat, monkeypatch, tmp_path):
         """Substantial p50 reduction maps to success and retains the aligned DEM."""
@@ -252,6 +281,93 @@ class TestAltimetry:
         assert fake_aligned.exists(), "aligned DEM should be retained"
         assert result.improvement_pct is not None
         assert result.improvement_pct > 5.0
+        assert result.message == (
+            f"p50 improved from 2.00 m -> 0.50 m (75.0% reduction). "
+            f"Aligned DEM written to {fake_aligned}."
+        )
+
+
+class TestAlignmentEvaluationHelpers:
+    """Unit tests for the shared keep/discard helpers backing both the
+    ICESat-2 and planetary align-and-evaluate paths."""
+
+    @pytest.fixture
+    def alt(self):
+        return Altimetry(
+            directory="tests/test_data",
+            dem_fn="tests/test_data/stereo/date_time_left_right_1m-DEM.tif",
+        )
+
+    def test_improvement_pct_normal(self, alt):
+        assert alt._improvement_pct(2.0, 0.5) == pytest.approx(75.0)
+        assert alt._improvement_pct(4.0, 4.0) == pytest.approx(0.0)
+
+    @pytest.mark.parametrize(
+        "p50_beg, p50_end",
+        [(float("nan"), 1.0), (1.0, float("nan")), (0.0, 1.0)],
+    )
+    def test_improvement_pct_returns_none(self, alt, p50_beg, p50_end):
+        assert alt._improvement_pct(p50_beg, p50_end) is None
+
+    def test_evaluate_improvement_keeps_good_alignment(self, alt):
+        # Good improvement, translation fine -> None signals "keep".
+        out = alt._evaluate_improvement(
+            df=pd.DataFrame([{"key": "all"}]),
+            p50_beg=2.0,
+            p50_end=0.5,
+            improvement_pct=75.0,
+            improvement_threshold_pct=5.0,
+            translation_too_small=False,
+            no_improvement_reason="unused",
+            parameters_used={},
+        )
+        assert out is None
+
+    @pytest.mark.parametrize(
+        "improvement_pct, p50_end, translation_too_small",
+        [
+            (0.0, 2.0, False),  # at/below threshold
+            (None, 2.0, False),  # not computable
+            (75.0, 0.5, True),  # good improvement but translation too small
+        ],
+    )
+    def test_evaluate_improvement_rejects_and_cleans_up(
+        self, alt, tmp_path, improvement_pct, p50_end, translation_too_small
+    ):
+        fake_aligned = tmp_path / "a_pc_align_translated.tif"
+        fake_aligned.write_bytes(b"dummy")
+        alt.aligned_dem_fn = str(fake_aligned)
+
+        out = alt._evaluate_improvement(
+            df=pd.DataFrame([{"key": "all"}]),
+            p50_beg=2.0,
+            p50_end=p50_end,
+            improvement_pct=improvement_pct,
+            improvement_threshold_pct=5.0,
+            translation_too_small=translation_too_small,
+            no_improvement_reason="my reason",
+            parameters_used={"x": 1},
+        )
+        assert out.status == "no_improvement"
+        assert out.aligned_dem_fn is None
+        assert out.message == "No significant improvement: my reason"
+        assert out.parameters_used == {"x": 1}
+        # The aligned DEM is cleaned up on rejection.
+        assert not fake_aligned.exists()
+        assert alt.aligned_dem_fn is None
+
+    def test_success_result_message(self, alt, tmp_path):
+        alt.aligned_dem_fn = str(tmp_path / "aligned.tif")
+        out = alt._success_result(
+            pd.DataFrame([{"key": "all"}]), 2.0, 0.5, 75.0, {"x": 1}
+        )
+        assert out.status == "success"
+        assert out.aligned_dem_fn == str(tmp_path / "aligned.tif")
+        assert out.improvement_pct == pytest.approx(75.0)
+        assert out.message == (
+            f"p50 improved from 2.00 m -> 0.50 m (75.0% reduction). "
+            f"Aligned DEM written to {tmp_path / 'aligned.tif'}."
+        )
 
 
 class TestLazySlideruleInit:
@@ -488,6 +604,62 @@ class TestPlanetaryDh:
         result = alt_with_points.align_and_evaluate_planetary(minimum_points=10_000)
         assert result.status == "insufficient_points"
         assert result.aligned_dem_fn is None
+
+    def test_align_and_evaluate_planetary_no_improvement(
+        self, alt_with_points, tmp_path, monkeypatch
+    ):
+        """End-to-end planetary path through the shared keep/discard helper:
+        pc_align reports no p50 change, so the aligned DEM is rejected with
+        the planetary-specific reason wording (no "Aligned DEM removed."
+        suffix; GSD value is included only on the translation branch)."""
+        alt = alt_with_points
+        alt.directory = str(tmp_path)
+        alt.planetary_points["radius_m"] = alt.planetary_points["height"] + 6_378_137.0
+
+        import asp_plot.altimetry as altmod
+
+        monkeypatch.setattr(
+            "asp_plot.utils.detect_planetary_body", lambda dem_fn: "mars"
+        )
+        monkeypatch.setattr(
+            Altimetry,
+            "to_csv_for_pc_align_planetary",
+            lambda self, filename_prefix="x": str(tmp_path / "p.csv"),
+        )
+
+        class FakeAlignment:
+            def __init__(self, directory, dem_fn):
+                pass
+
+            def pc_align_dem_to_planetary_csv(self, **kwargs):
+                pass
+
+            def pc_align_report(self, output_prefix):
+                # No improvement: p50 unchanged; translation large enough that
+                # translation_too_small is False (forces the threshold branch).
+                return {
+                    "p50_beg": 2.0,
+                    "p50_end": 2.0,
+                    "translation_magnitude": 5.0,
+                }
+
+        class FakeRaster:
+            def __init__(self, fn):
+                pass
+
+            def get_gsd(self):
+                return 1.0
+
+        monkeypatch.setattr(altmod, "Alignment", FakeAlignment)
+        monkeypatch.setattr(altmod, "Raster", FakeRaster)
+
+        result = alt.align_and_evaluate_planetary(minimum_points=1)
+        assert result.status == "no_improvement"
+        assert result.aligned_dem_fn is None
+        assert result.message == (
+            "No significant improvement: p50 2.00 m -> 2.00 m, 0.0% <= 5.0% "
+            "threshold."
+        )
 
 
 class TestLoadPlanetaryCsv:


### PR DESCRIPTION
Closes #127. Builds on #126 (Body abstraction). Part of #122.

## What

Unifies two near-duplicate clusters of alignment code behind shared helpers.

**`alignment.py` — one `pc_align` runner.** `pc_align_dem_to_atl06sr` (ICESat-2) and `pc_align_dem_to_planetary_csv` (LOLA/MOLA) were ~75% identical argv scaffolds. Both now delegate to a private `_run_pc_align(csv, csv_format, max_displacement, datum=None, ...)`. The public methods keep their exact signatures, validation, and error messages. The `--datum` flag is emitted only when a datum is passed (planetary path).

**`altimetry.py` — shared keep/discard logic.** `align_and_evaluate` and `align_and_evaluate_planetary` shared a ~150-line p50-improvement / threshold / cleanup decision tree. Extracted:
- `_improvement_pct(p50_beg, p50_end)` — the reduction computation
- `_evaluate_improvement(...)` — the rejection predicate + `no_improvement` `AlignmentResult` assembly (and aligned-DEM cleanup)
- `_success_result(...)` — the identical success `AlignmentResult`

The per-body **`no_improvement` reason wording stays with each caller** (Earth and planetary genuinely differ: planetary includes the GSD value, Earth appends "Aligned DEM removed." and gates the translation-wording differently), so messages and behavior are unchanged.

## Behavior

No user-visible change. Verified the `pc_align` **argv and stdout are byte-for-byte identical** to the pre-refactor inline commands for both bodies. The improvement computation, rejection predicate, and result messages are preserved verbatim — just relocated.

No new imports from `report.py`/`fpdf` (`AlignmentResult` stays import-light for notebook callers).

## Tests
- **New `tests/test_alignment.py`** — pins the `_run_pc_align` argv for both the ICESat-2 and planetary paths (incl. the `--datum` presence/absence) plus the validation/error branches.
- **`test_altimetry.py`** — new `TestAlignmentEvaluationHelpers` (unit tests for all three helpers, including cleanup-on-reject), exact `no_improvement`/`success` message assertions for the Earth path, the Earth **translation-too-small** branch (previously untested), and an end-to-end **planetary `no_improvement`** test exercising the shared helper.
- Full suite: **216 passed**. New assertions confirmed to have teeth via local mutation checks (argv, predicate, message wording).

## Acceptance criteria (from #127)
- [x] Single `_run_pc_align(...)` backing both ICESat-2 and planetary paths
- [x] Single `_evaluate_improvement(...)` returning `AlignmentResult` for both bodies (+ `_improvement_pct`/`_success_result` so the per-body message wording is preserved exactly)
- [x] No new imports from `report.py`/`fpdf` in `altimetry.py`/`alignment.py`
- [x] `test_altimetry.py` green; alignment behavior unchanged