### PR TITLE
Sensor-flexible metadata parsing + compose the geometry plotter (#25)

### DIFF
--- a/asp_plot/cli/stereo_geom.py
+++ b/asp_plot/cli/stereo_geom.py
@@ -37,7 +37,7 @@ def main(
     output_filename,
 ):
     """
-    Generate stereo geometry plots for DigitalGlobe/Maxar XML files.
+    Generate stereo geometry plots for WorldView XML files.
     This tool creates a skyplot and map visualization of the satellite positions and ground footprints.
     """
     directory = os.path.expanduser(directory)

--- a/asp_plot/sensors.py
+++ b/asp_plot/sensors.py
@@ -4,10 +4,10 @@ This module isolates the *sensor-specific* work of discovering scene files and
 extracting per-scene metadata from the *sensor-agnostic* stereo-pair geometry
 math in :mod:`asp_plot.stereopair_metadata_parser`.
 
-The goal is flexibility: today only DigitalGlobe/Maxar XML camera files are
-supported, but adding a new sensor (ASTER, HiRISE, etc.) is a matter of writing
-a new :class:`SensorMetadata` subclass and registering it in ``SENSORS`` — no
-changes to the pair-level geometry code are required.
+The goal is flexibility: today only WorldView (and other DigitalGlobe-heritage)
+XML camera files are supported, but adding a new sensor (ASTER, HiRISE, etc.) is
+a matter of writing a new :class:`SensorMetadata` subclass and registering it in
+``SENSORS`` — no changes to the pair-level geometry code are required.
 
 Each reader is responsible for turning a directory of camera/metadata files into
 a list of *scene dicts*, one per scene, each containing the sensor-agnostic keys
@@ -53,7 +53,7 @@ class SensorMetadata(ABC):
     Attributes
     ----------
     name : str
-        Human-readable sensor name (e.g. ``"DigitalGlobe/Maxar"``).
+        Human-readable sensor name (e.g. ``"WorldView"``).
     directory : str
         Path to the directory containing the sensor's metadata files.
     """
@@ -98,12 +98,13 @@ class SensorMetadata(ABC):
         raise NotImplementedError
 
 
-class DigitalGlobeMetadata(SensorMetadata):
-    """Metadata reader for DigitalGlobe/Maxar satellite XML camera files.
+class WorldViewMetadata(SensorMetadata):
+    """Metadata reader for WorldView satellite XML camera files.
 
-    Parses Digital Globe/Maxar (and similar) satellite XML files to extract
-    per-scene metadata, handling both single XML files and multiple XML tiles
-    per scene (mosaicked with ``dg_mosaic``).
+    Parses WorldView (and other DigitalGlobe-heritage products that share the
+    same XML format, e.g. GeoEye-1, QuickBird, IKONOS) satellite XML files to
+    extract per-scene metadata, handling both single XML files and multiple XML
+    tiles per scene (mosaicked with ``dg_mosaic``).
 
     Attributes
     ----------
@@ -113,11 +114,11 @@ class DigitalGlobeMetadata(SensorMetadata):
         List of XML files found in the directory.
     """
 
-    name = "DigitalGlobe/Maxar"
+    name = "WorldView"
 
     def __init__(self, directory):
         """
-        Initialize the DigitalGlobe/Maxar metadata reader.
+        Initialize the WorldView metadata reader.
 
         Parameters
         ----------
@@ -169,7 +170,7 @@ class DigitalGlobeMetadata(SensorMetadata):
         Returns
         -------
         bool
-            Whether DigitalGlobe/Maxar XML camera files were found.
+            Whether WorldView XML camera files were found.
         """
         return bool(cls._discover_xmls(os.path.expanduser(directory)))
 
@@ -552,7 +553,7 @@ class DigitalGlobeMetadata(SensorMetadata):
 
 
 # Registry of available sensor readers, in detection-priority order.
-SENSORS = [DigitalGlobeMetadata]
+SENSORS = [WorldViewMetadata]
 
 
 def sensor_for_directory(directory):

--- a/asp_plot/sensors.py
+++ b/asp_plot/sensors.py
@@ -1,0 +1,586 @@
+"""Sensor-specific metadata readers for stereo scenes.
+
+This module isolates the *sensor-specific* work of discovering scene files and
+extracting per-scene metadata from the *sensor-agnostic* stereo-pair geometry
+math in :mod:`asp_plot.stereopair_metadata_parser`.
+
+The goal is flexibility: today only DigitalGlobe/Maxar XML camera files are
+supported, but adding a new sensor (ASTER, HiRISE, etc.) is a matter of writing
+a new :class:`SensorMetadata` subclass and registering it in ``SENSORS`` — no
+changes to the pair-level geometry code are required.
+
+Each reader is responsible for turning a directory of camera/metadata files into
+a list of *scene dicts*, one per scene, each containing the sensor-agnostic keys
+the geometry code consumes:
+
+``xml_fn``, ``catid``, ``sensor``, ``date``, ``scandir``, ``tdi``, ``geom``
+(a Shapely polygon footprint in EPSG:4326), the mean view-angle/GSD/sun
+attributes (``meansataz``, ``meansatel``, ``meanoffnadirviewangle``,
+``meanintrackviewangle``, ``meancrosstrackviewangle``, ``meanproductgsd``,
+``meansunaz``, ``meansunel``, ``cloudcover``), and — when ``geteph`` is True —
+``eph_gdf`` (ephemeris GeoDataFrame in EPSG:4978), ``att_df`` (attitude
+DataFrame), and ``fp_gdf`` (footprint GeoDataFrame in EPSG:4326).
+"""
+
+import logging
+import os
+import re
+from abc import ABC, abstractmethod
+from datetime import datetime
+
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+from shapely import union_all, wkt
+
+from asp_plot.utils import get_xml_tag, glob_file, run_subprocess_command
+
+logging.basicConfig(level=logging.WARNING)
+logger = logging.getLogger(__name__)
+
+
+class SensorMetadata(ABC):
+    """Abstract base class for a single sensor's metadata reader.
+
+    A concrete reader discovers the scene files for one sensor in a directory and
+    extracts a list of sensor-agnostic *scene dicts* (see the module docstring
+    for the schema) that the stereo-pair geometry code can consume without
+    knowing which sensor produced them.
+
+    Subclasses must implement :meth:`detect` (so the sensor can be chosen
+    automatically) and :meth:`get_scene_dicts`.
+
+    Attributes
+    ----------
+    name : str
+        Human-readable sensor name (e.g. ``"DigitalGlobe/Maxar"``).
+    directory : str
+        Path to the directory containing the sensor's metadata files.
+    """
+
+    name = "sensor"
+
+    def __init__(self, directory):
+        """
+        Parameters
+        ----------
+        directory : str
+            Path to directory containing the sensor's camera/metadata files.
+        """
+        self.directory = os.path.expanduser(directory)
+
+    @classmethod
+    @abstractmethod
+    def detect(cls, directory):
+        """Return True if this reader can handle the files in ``directory``.
+
+        Parameters
+        ----------
+        directory : str
+            Path to directory to inspect.
+
+        Returns
+        -------
+        bool
+            Whether this sensor's metadata files are present.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_scene_dicts(self):
+        """Return a list of per-scene metadata dictionaries.
+
+        Returns
+        -------
+        list of dict
+            One sensor-agnostic scene dict per scene (see module docstring).
+        """
+        raise NotImplementedError
+
+
+class DigitalGlobeMetadata(SensorMetadata):
+    """Metadata reader for DigitalGlobe/Maxar satellite XML camera files.
+
+    Parses Digital Globe/Maxar (and similar) satellite XML files to extract
+    per-scene metadata, handling both single XML files and multiple XML tiles
+    per scene (mosaicked with ``dg_mosaic``).
+
+    Attributes
+    ----------
+    directory : str
+        Path to directory containing XML files.
+    image_list : list
+        List of XML files found in the directory.
+    """
+
+    name = "DigitalGlobe/Maxar"
+
+    def __init__(self, directory):
+        """
+        Initialize the DigitalGlobe/Maxar metadata reader.
+
+        Parameters
+        ----------
+        directory : str
+            Path to directory containing XML camera model files.
+
+        Raises
+        ------
+        ValueError
+            If no XML files are found in the directory.
+        """
+        super().__init__(directory)
+
+        self.image_list = self._discover_xmls(self.directory)
+
+        if not self.image_list:
+            raise ValueError(
+                "\n\nMissing XML camera files in directory. Cannot extract metadata without these.\n\n"
+            )
+
+    @staticmethod
+    def _discover_xmls(directory):
+        """Glob non-ortho XML camera files in ``directory``.
+
+        Parameters
+        ----------
+        directory : str
+            Path to directory to search.
+
+        Returns
+        -------
+        list
+            List of XML file paths, excluding ``*ortho*.xml`` files.
+        """
+        # glob_file returns None (not []) when nothing matches
+        image_list = glob_file(directory, "*.[Xx][Mm][Ll]", all_files=True) or []
+        # Drop potential *ortho*.xml files from image_list
+        return [file for file in image_list if not re.search(r".*ortho.*\.xml", file)]
+
+    @classmethod
+    def detect(cls, directory):
+        """Return True if non-ortho XML camera files are present.
+
+        Parameters
+        ----------
+        directory : str
+            Path to directory to inspect.
+
+        Returns
+        -------
+        bool
+            Whether DigitalGlobe/Maxar XML camera files were found.
+        """
+        return bool(cls._discover_xmls(os.path.expanduser(directory)))
+
+    def get_scene_dicts(self):
+        """
+        Get dictionaries of metadata for each catalog ID.
+
+        Builds dictionaries of metadata for each catalog ID found in the XML files.
+
+        Returns
+        -------
+        list
+            List of dictionaries, one for each catalog ID, containing metadata
+        """
+        catid_xmls = self.get_catid_xmls()
+        catid_dicts = []
+        for catid, xml in catid_xmls.items():
+            catid_dicts.append(self.get_id_dict(catid, xml))
+        return catid_dicts
+
+    def get_catid_xmls(self):
+        """
+        Get XML files associated with each catalog ID.
+
+        Checks for multiple XML files for each catalog ID and handles mosaicking
+        if needed.
+
+        Returns
+        -------
+        dict
+            Dictionary mapping catalog IDs to XML file paths
+
+        Notes
+        -----
+        If more than two XML files are found, they will be mosaicked using
+        dg_mosaic before proceeding.
+        """
+        # First check for multiple XML files and dg_mosaic if needed
+        if len(self.image_list) > 2:
+            print(
+                "\nMore than two XML files found in directory. Mosaicking before proceeding.\n"
+            )
+            self.mosaic_multiple_xmls()
+
+        # Get CATIDs
+        catid_xmls = {}
+        for xml_file in self.image_list:
+            catid = get_xml_tag(xml_file, "CATID")
+            catid_xmls[catid] = xml_file
+
+        # TODO: need to improve logic and looping here and in get_id_dict for dictionary creation when
+        # there are multiple XML files for a given scene
+        # use ~/Desktop/asp-plot-examples/antarctica/tiled_xmls_example for testing this
+
+        return catid_xmls
+
+    def mosaic_multiple_xmls(self):
+        """
+        Mosaic multiple XML files for each catalog ID.
+
+        Uses dg_mosaic to merge multiple XML files for the same catalog ID
+        into a single XML file. This is needed when a scene is composed of
+        multiple image tiles.
+
+        Returns
+        -------
+        None
+            Updates the image_list attribute with mosaicked XML files
+
+        Notes
+        -----
+        Requires dg_mosaic from the NASA Ames Stereo Pipeline to be installed
+        and available in the system path.
+        """
+        # Drop existing *.r100.* and *.r50.* files from image_list if they are present
+        self.image_list = [
+            file
+            for file in self.image_list
+            if not re.search(r"\.r100\..*|\.r50\..*", file)
+        ]
+
+        # Group XML files by CATID
+        catid_xml_dict = {}
+        for xml_file in self.image_list:
+            catid = get_xml_tag(xml_file, "CATID")
+            if catid not in catid_xml_dict:
+                catid_xml_dict[catid] = []
+            catid_xml_dict[catid].append(xml_file)
+
+        # Convert lists to space-separated strings
+        catid_xml_dict = {
+            catid: " ".join(xml_files) for catid, xml_files in catid_xml_dict.items()
+        }
+
+        # Run dg_mosaic with: dg_mosaic --skip-tif-gen --output-prefix <NAME> <SPACE SEPARATED XML FILES>
+        output_xmls = []
+        for catid, xml_files in catid_xml_dict.items():
+            output_xml = os.path.join(self.directory, f"{catid}_asp_plot_dg_mosaic")
+            output_xml_r100 = f"{output_xml}.r100.xml"
+
+            if not os.path.exists(output_xml_r100):
+                # Build the command string instead of a list, needed for subprocess call, .split() below
+                command = (
+                    f"dg_mosaic --skip-tif-gen --output-prefix {output_xml} {xml_files}"
+                )
+
+                print(f"\nRunning dg_mosaic with command: {command}\n")
+
+                # Run the command
+                run_subprocess_command(command.split())
+            else:
+                print(f"\nUsing existing mosaicked XML file: {output_xml_r100}\n")
+
+            output_xmls.append(output_xml_r100)
+
+        # Then create the new image list with just the mosaicked XML files
+        self.image_list = []
+        for output_xml in output_xmls:
+            self.image_list.append(output_xml)
+
+    def get_id_dict(self, catid, xml, geteph=True):
+        """
+        Get a dictionary of metadata for a specific catalog ID.
+
+        Extracts metadata from XML file for a given catalog ID, including
+        satellite parameters, acquisition angles, and geometry.
+
+        Parameters
+        ----------
+        catid : str
+            Catalog ID for the satellite image
+        xml : str
+            Path to the XML file
+        geteph : bool, optional
+            Whether to extract ephemeris data, default is True
+
+        Returns
+        -------
+        dict
+            Dictionary containing metadata for the catalog ID
+
+        Notes
+        -----
+        The dictionary includes satellite ID, acquisition date, scan direction,
+        TDI level, geometry information, and various mean angles and parameters.
+        If geteph is True, also includes ephemeris and footprint GeoDataFrames.
+        """
+
+        def list_average(list):
+            """Calculate average of values in a list, handling NaN values."""
+            return np.round(pd.Series(list, dtype=float).dropna().mean(), 2)
+
+        attributes = {
+            "MEANSATAZ": [],
+            "MEANSATEL": [],
+            "MEANOFFNADIRVIEWANGLE": [],
+            "MEANINTRACKVIEWANGLE": [],
+            "MEANCROSSTRACKVIEWANGLE": [],
+            "MEANPRODUCTGSD": [],
+            "MEANSUNAZ": [],
+            "MEANSUNEL": [],
+            "CLOUDCOVER": [],
+            "geom": [],
+        }
+
+        for tag, lst in attributes.items():
+            if tag != "geom":
+                lst.append(get_xml_tag(xml, tag))
+            else:
+                # This returns a Shapely Polygon geometry
+                lst.append(self.xml2poly(xml))
+
+        d = {
+            "xml_fn": xml,
+            "catid": catid,
+            "sensor": get_xml_tag(xml, "SATID"),
+            "date": datetime.strptime(
+                get_xml_tag(xml, "FIRSTLINETIME"), "%Y-%m-%dT%H:%M:%S.%fZ"
+            ),
+            "scandir": get_xml_tag(xml, "SCANDIRECTION"),
+            "tdi": int(get_xml_tag(xml, "TDILEVEL")),
+            "geom": union_all(attributes["geom"]),
+        }
+
+        # Add Ephemeris GeoDataFrame, Attitude DataFrame, and Footprint GeoDataFrame
+        if geteph:
+            d["eph_gdf"] = self.getEphem_gdf(xml)
+            d["att_df"] = self.getAtt_df(xml)
+            d["fp_gdf"] = gpd.GeoDataFrame(
+                {"idx": [0], "geometry": d["geom"]},
+                geometry="geometry",
+                crs="EPSG:4326",
+            )
+
+        # Compute mean values when multiple xml make up a single image ID
+        for tag, lst in attributes.items():
+            if tag != "geom":
+                d[tag.lower()] = list_average(lst)
+
+        return d
+
+    def getEphem(self, xml):
+        """
+        Extract ephemeris data from XML file.
+
+        Retrieves satellite ephemeris (position and velocity) data from the XML file.
+
+        Parameters
+        ----------
+        xml : str
+            Path to the XML file
+
+        Returns
+        -------
+        numpy.ndarray
+            Array containing ephemeris data with columns:
+            point_num, Xpos, Ypos, Zpos, Xvel, Yvel, Zvel, and covariance matrix elements
+
+        Notes
+        -----
+        All coordinates are in Earth-Centered Fixed (ECF) reference frame.
+        Units are meters for positions, meters/sec for velocities, and m^2 for covariance.
+        """
+        e = get_xml_tag(xml, "EPHEMLIST", all=True)
+        # Could get fancy with structured array here
+        # point_num, Xpos, Ypos, Zpos, Xvel, Yvel, Zvel, covariance matrix (6 elements)
+        # dtype=[('point', 'i4'), ('Xpos', 'f8'), ('Ypos', 'f8'), ('Zpos', 'f8'), ('Xvel', 'f8') ...]
+        # All coordinates are ECF, meters, meters/sec, m^2
+        return np.array([i.split() for i in e], dtype=np.float64)
+
+    def getAtt(self, xml):
+        """
+        Extract attitude data from XML file.
+
+        Retrieves satellite attitude (orientation quaternion and covariance) data
+        from the XML file.
+
+        Parameters
+        ----------
+        xml : str
+            Path to the XML file
+
+        Returns
+        -------
+        numpy.ndarray
+            Array of shape (N, 15) containing attitude data with columns:
+            point_num, q1, q2, q3, q4, and 10 covariance matrix elements
+            (upper triangle of 4x4 matrix)
+        """
+        a = get_xml_tag(xml, "ATTLIST", all=True)
+        return np.array([i.split() for i in a], dtype=np.float64)
+
+    def getEphem_gdf(self, xml):
+        """
+        Create a GeoDataFrame from ephemeris data.
+
+        Converts ephemeris data to a GeoDataFrame with time index and Point geometry.
+
+        Parameters
+        ----------
+        xml : str
+            Path to the XML file
+
+        Returns
+        -------
+        geopandas.GeoDataFrame
+            GeoDataFrame with ephemeris data and Point geometries in EPSG:4978
+
+        Notes
+        -----
+        The GeoDataFrame uses EPSG:4978 (Earth-Centered Earth-Fixed) CRS and
+        has a time index corresponding to the acquisition times.
+        """
+        names = [
+            "index",
+        ]
+        names.extend(["x", "y", "z"])
+        names.extend(["dx", "dy", "dz"])
+        names.extend(["cov_{}".format(n) for n in ["11", "12", "13", "22", "23", "33"]])
+        e = self.getEphem(xml)
+        t0 = pd.to_datetime(get_xml_tag(xml, "STARTTIME"))
+        dt = pd.Timedelta(float(get_xml_tag(xml, "TIMEINTERVAL")), unit="s")
+        eph_df = pd.DataFrame(e, columns=names)
+        eph_df["time"] = t0 + eph_df.index * dt
+        eph_df.set_index("time", inplace=True)
+        eph_gdf = gpd.GeoDataFrame(
+            eph_df,
+            geometry=gpd.points_from_xy(eph_df["x"], eph_df["y"], eph_df["z"]),
+            crs="EPSG:4978",
+        )
+        return eph_gdf
+
+    def getAtt_df(self, xml):
+        """
+        Create a DataFrame from attitude data.
+
+        Converts attitude data to a DataFrame with time index.
+
+        Parameters
+        ----------
+        xml : str
+            Path to the XML file
+
+        Returns
+        -------
+        pandas.DataFrame
+            DataFrame with attitude quaternions and covariance, time-indexed
+        """
+        names = ["index", "q1", "q2", "q3", "q4"]
+        names.extend(
+            [
+                "cov_{}".format(n)
+                for n in ["11", "12", "13", "14", "22", "23", "24", "33", "34", "44"]
+            ]
+        )
+        a = self.getAtt(xml)
+        t0 = pd.to_datetime(get_xml_tag(xml, "STARTTIME"))
+        dt = pd.Timedelta(float(get_xml_tag(xml, "TIMEINTERVAL")), unit="s")
+        att_df = pd.DataFrame(a, columns=names)
+        att_df["time"] = t0 + att_df.index * dt
+        att_df.set_index("time", inplace=True)
+        return att_df
+
+    def xml2wkt(self, xml):
+        """
+        Convert XML corner coordinates to WKT polygon string.
+
+        Extracts corner coordinates from XML file and converts them to a
+        Well-Known Text (WKT) polygon string.
+
+        Parameters
+        ----------
+        xml : str
+            Path to the XML file
+
+        Returns
+        -------
+        str
+            WKT polygon string representation of image footprint
+
+        Notes
+        -----
+        Uses ULLON/ULLAT, URLON/URLAT, LRLON/LRLAT, LLLON/LLLAT tags
+        (Upper-Left, Upper-Right, Lower-Right, Lower-Left corners).
+        """
+        tags = [
+            ("ULLON", "ULLAT"),
+            ("URLON", "URLAT"),
+            ("LRLON", "LRLAT"),
+            ("LLLON", "LLLAT"),
+            ("ULLON", "ULLAT"),
+        ]
+        coords = []
+        for lon_tag, lat_tag in tags:
+            lon = get_xml_tag(xml, lon_tag)
+            lat = get_xml_tag(xml, lat_tag)
+            if lon and lat:
+                coords.append(f"{lon} {lat}")
+        geom_wkt = f"POLYGON(({', '.join(coords)}))"
+        return geom_wkt
+
+    def xml2poly(self, xml):
+        """
+        Convert XML corner coordinates to Shapely Polygon.
+
+        Reads XML file and converts corner coordinates to a Shapely Polygon geometry.
+
+        Parameters
+        ----------
+        xml : str
+            Path to the XML file
+
+        Returns
+        -------
+        shapely.geometry.Polygon
+            Polygon geometry representing the image footprint
+        """
+        geom_wkt = self.xml2wkt(xml)
+        return wkt.loads(geom_wkt)
+
+
+# Registry of available sensor readers, in detection-priority order.
+SENSORS = [DigitalGlobeMetadata]
+
+
+def sensor_for_directory(directory):
+    """Detect and instantiate the appropriate sensor reader for a directory.
+
+    Iterates the ``SENSORS`` registry and returns an instance of the first
+    reader whose :meth:`SensorMetadata.detect` matches the directory contents.
+
+    Parameters
+    ----------
+    directory : str
+        Path to directory containing camera/metadata files.
+
+    Returns
+    -------
+    SensorMetadata
+        An initialized reader for the detected sensor.
+
+    Raises
+    ------
+    ValueError
+        If no registered sensor reader matches the directory contents.
+    """
+    directory = os.path.expanduser(directory)
+    for sensor_cls in SENSORS:
+        if sensor_cls.detect(directory):
+            return sensor_cls(directory)
+    raise ValueError(
+        "\n\nNo supported sensor metadata files found in directory. "
+        f"Supported sensors: {', '.join(s.name for s in SENSORS)}.\n\n"
+    )

--- a/asp_plot/stereo_geometry.py
+++ b/asp_plot/stereo_geometry.py
@@ -13,22 +13,25 @@ logging.basicConfig(level=logging.WARNING)
 logger = logging.getLogger(__name__)
 
 
-class StereoGeometryPlotter(StereopairMetadataParser):
+class StereoGeometryPlotter:
     """
     Create visualizations of stereo geometry for satellite imagery.
 
-    This class extends StereopairMetadataParser to provide plotting capabilities
-    for stereo geometry visualization, including skyplots showing satellite viewing
-    angles and map views showing footprints and satellite positions.
+    This class *composes* a :class:`StereopairMetadataParser` to provide plotting
+    capabilities for stereo geometry visualization, including skyplots showing
+    satellite viewing angles and map views showing footprints and satellite
+    positions. Metadata access goes through the ``parser`` attribute rather than
+    inheritance, keeping the (sensor-agnostic) plotting concerns separate from
+    the (sensor-specific) metadata parsing.
 
     Attributes
     ----------
     directory : str
         Path to directory containing XML files
+    parser : StereopairMetadataParser
+        The composed metadata parser used to extract stereo-pair geometry
     add_basemap : bool
         Whether to add a basemap to map plots, default is True
-    image_list : list
-        List of XML files found in the directory (inherited from StereopairMetadataParser)
 
     Examples
     --------
@@ -49,7 +52,8 @@ class StereoGeometryPlotter(StereopairMetadataParser):
         **kwargs
             Additional keyword arguments passed to StereopairMetadataParser
         """
-        super().__init__(directory=directory, **kwargs)
+        self.directory = directory
+        self.parser = StereopairMetadataParser(directory=directory, **kwargs)
         self.add_basemap = add_basemap
 
     def get_scene_string(self, p, key="catid1_dict"):
@@ -301,7 +305,7 @@ class StereoGeometryPlotter(StereopairMetadataParser):
         intersection of the two image footprints to minimize distortion.
         """
         # load pair information as dict
-        p = self.get_pair_dict()
+        p = self.parser.get_pair_dict()
 
         fig = plt.figure(figsize=(10, 7.5))
         G = gridspec.GridSpec(nrows=1, ncols=2)
@@ -312,7 +316,9 @@ class StereoGeometryPlotter(StereopairMetadataParser):
 
         # Use local projection to minimize distortion
         # Should be OK to use transverse mercator here, usually within ~2-3 deg
-        map_crs = self.get_centroid_projection(p["intersection"], proj_type="tmerc")
+        map_crs = self.parser.get_centroid_projection(
+            p["intersection"], proj_type="tmerc"
+        )
 
         self.map_plot(
             ax1,
@@ -385,9 +391,11 @@ class StereoGeometryPlotter(StereopairMetadataParser):
         matplotlib.figure.Figure
             The created figure object (not shown automatically)
         """
-        p = self.get_pair_dict()
+        p = self.parser.get_pair_dict()
 
-        map_crs = self.get_centroid_projection(p["intersection"], proj_type="tmerc")
+        map_crs = self.parser.get_centroid_projection(
+            p["intersection"], proj_type="tmerc"
+        )
 
         fig = plt.figure(figsize=(14, 12))
         G = gridspec.GridSpec(nrows=3, ncols=2, hspace=0.35, wspace=0.3)

--- a/asp_plot/stereopair_metadata_parser.py
+++ b/asp_plot/stereopair_metadata_parser.py
@@ -1,15 +1,14 @@
 import logging
 import os
-import re
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import geopandas as gpd
 import numpy as np
-import pandas as pd
 from osgeo import osr
-from shapely import union_all, wkt
+from shapely import union_all
 
-from asp_plot.utils import get_utm_epsg, get_xml_tag, glob_file, run_subprocess_command
+from asp_plot.sensors import sensor_for_directory
+from asp_plot.utils import get_utm_epsg
 
 osr.UseExceptions()
 logging.basicConfig(level=logging.WARNING)
@@ -167,18 +166,27 @@ def get_asymmetry_angle(sat1_pos, sat2_pos, ground_point):
 # TODO: When this supports N scenes, should rename to StereoMetadataParser
 class StereopairMetadataParser:
     """
-    Parse metadata from satellite sensor XML files for stereo pairs.
+    Parse metadata for a stereo pair and compute stereo-geometry parameters.
 
-    This class parses Digital Globe/Maxar or similar satellite XML files to extract
-    metadata and compute stereo geometry parameters. It handles single XML files
-    as well as multiple XML files per scene, where mosaicking is required.
+    This class is sensor-agnostic: the work of discovering scene files and
+    extracting per-scene metadata is delegated to a sensor-specific reader (see
+    :mod:`asp_plot.sensors`), chosen automatically by inspecting the directory
+    contents. The parser then computes pair-level geometry (convergence angle,
+    base-to-height ratio, bisector elevation angle, asymmetry angle, footprint
+    intersection, bounds) from the resulting scene dictionaries.
+
+    Adding support for a new sensor (ASTER, HiRISE, etc.) is a matter of writing
+    a new :class:`asp_plot.sensors.SensorMetadata` subclass; no changes to this
+    class are required.
 
     Attributes
     ----------
     directory : str
-        Path to directory containing XML files
+        Path to directory containing the scene metadata files
+    reader : asp_plot.sensors.SensorMetadata
+        The detected sensor-specific metadata reader
     image_list : list
-        List of XML files found in the directory
+        List of scene metadata files found in the directory (delegated to the reader)
 
     Examples
     --------
@@ -192,29 +200,26 @@ class StereopairMetadataParser:
         """
         Initialize the StereopairMetadataParser.
 
+        Detects the sensor from the directory contents and builds the matching
+        metadata reader.
+
         Parameters
         ----------
         directory : str
-            Path to directory containing XML camera model files
+            Path to directory containing camera model / metadata files
 
         Raises
         ------
         ValueError
-            If no XML files are found in the directory
+            If no supported sensor metadata files are found in the directory
         """
         self.directory = os.path.expanduser(directory)
+        self.reader = sensor_for_directory(self.directory)
 
-        self.image_list = glob_file(self.directory, "*.[Xx][Mm][Ll]", all_files=True)
-
-        # Drop potential *ortho*.xml files from image_list
-        self.image_list = [
-            file for file in self.image_list if not re.search(r".*ortho.*\.xml", file)
-        ]
-
-        if not self.image_list:
-            raise ValueError(
-                "\n\nMissing XML camera files in directory. Cannot extract metadata without these.\n\n"
-            )
+    @property
+    def image_list(self):
+        """List of scene metadata files (delegated to the sensor reader)."""
+        return self.reader.image_list
 
     # TODO: This method assumes that only two scenes are captured with get_catid_dicts
     # Should be updated to support more than two scenes, or need a separate method for N scenes
@@ -244,378 +249,15 @@ class StereopairMetadataParser:
         """
         Get dictionaries of metadata for each catalog ID.
 
-        Builds dictionaries of metadata for each catalog ID found in the XML files.
+        Delegates to the detected sensor reader to build a list of per-scene
+        metadata dictionaries.
 
         Returns
         -------
         list
             List of dictionaries, one for each catalog ID, containing metadata
         """
-        catid_xmls = self.get_catid_xmls()
-        catid_dicts = []
-        for catid, xml in catid_xmls.items():
-            catid_dicts.append(self.get_id_dict(catid, xml))
-        return catid_dicts
-
-    def get_catid_xmls(self):
-        """
-        Get XML files associated with each catalog ID.
-
-        Checks for multiple XML files for each catalog ID and handles mosaicking
-        if needed.
-
-        Returns
-        -------
-        dict
-            Dictionary mapping catalog IDs to XML file paths
-
-        Notes
-        -----
-        If more than two XML files are found, they will be mosaicked using
-        dg_mosaic before proceeding.
-        """
-        # First check for multiple XML files and dg_mosaic if needed
-        if len(self.image_list) > 2:
-            print(
-                "\nMore than two XML files found in directory. Mosaicking before proceeding.\n"
-            )
-            self.mosaic_multiple_xmls()
-
-        # Get CATIDs
-        catid_xmls = {}
-        for xml_file in self.image_list:
-            catid = get_xml_tag(xml_file, "CATID")
-            catid_xmls[catid] = xml_file
-
-        # TODO: need to improve logic and looping here and in get_id_dict for dictionary creation when
-        # there are multiple XML files for a given scene
-        # use ~/Desktop/asp-plot-examples/antarctica/tiled_xmls_example for testing this
-
-        return catid_xmls
-
-    def mosaic_multiple_xmls(self):
-        """
-        Mosaic multiple XML files for each catalog ID.
-
-        Uses dg_mosaic to merge multiple XML files for the same catalog ID
-        into a single XML file. This is needed when a scene is composed of
-        multiple image tiles.
-
-        Returns
-        -------
-        None
-            Updates the image_list attribute with mosaicked XML files
-
-        Notes
-        -----
-        Requires dg_mosaic from the NASA Ames Stereo Pipeline to be installed
-        and available in the system path.
-        """
-        # Drop existing *.r100.* and *.r50.* files from image_list if they are present
-        self.image_list = [
-            file
-            for file in self.image_list
-            if not re.search(r"\.r100\..*|\.r50\..*", file)
-        ]
-
-        # Group XML files by CATID
-        catid_xml_dict = {}
-        for xml_file in self.image_list:
-            catid = get_xml_tag(xml_file, "CATID")
-            if catid not in catid_xml_dict:
-                catid_xml_dict[catid] = []
-            catid_xml_dict[catid].append(xml_file)
-
-        # Convert lists to space-separated strings
-        catid_xml_dict = {
-            catid: " ".join(xml_files) for catid, xml_files in catid_xml_dict.items()
-        }
-
-        # Run dg_mosaic with: dg_mosaic --skip-tif-gen --output-prefix <NAME> <SPACE SEPARATED XML FILES>
-        output_xmls = []
-        for catid, xml_files in catid_xml_dict.items():
-            output_xml = os.path.join(self.directory, f"{catid}_asp_plot_dg_mosaic")
-            output_xml_r100 = f"{output_xml}.r100.xml"
-
-            if not os.path.exists(output_xml_r100):
-                # Build the command string instead of a list, needed for subprocess call, .split() below
-                command = (
-                    f"dg_mosaic --skip-tif-gen --output-prefix {output_xml} {xml_files}"
-                )
-
-                print(f"\nRunning dg_mosaic with command: {command}\n")
-
-                # Run the command
-                run_subprocess_command(command.split())
-            else:
-                print(f"\nUsing existing mosaicked XML file: {output_xml_r100}\n")
-
-            output_xmls.append(output_xml_r100)
-
-        # Then create the new image list with just the mosaicked XML files
-        self.image_list = []
-        for output_xml in output_xmls:
-            self.image_list.append(output_xml)
-
-    def get_id_dict(self, catid, xml, geteph=True):
-        """
-        Get a dictionary of metadata for a specific catalog ID.
-
-        Extracts metadata from XML file for a given catalog ID, including
-        satellite parameters, acquisition angles, and geometry.
-
-        Parameters
-        ----------
-        catid : str
-            Catalog ID for the satellite image
-        xml : str
-            Path to the XML file
-        geteph : bool, optional
-            Whether to extract ephemeris data, default is True
-
-        Returns
-        -------
-        dict
-            Dictionary containing metadata for the catalog ID
-
-        Notes
-        -----
-        The dictionary includes satellite ID, acquisition date, scan direction,
-        TDI level, geometry information, and various mean angles and parameters.
-        If geteph is True, also includes ephemeris and footprint GeoDataFrames.
-        """
-
-        def list_average(list):
-            """Calculate average of values in a list, handling NaN values."""
-            return np.round(pd.Series(list, dtype=float).dropna().mean(), 2)
-
-        attributes = {
-            "MEANSATAZ": [],
-            "MEANSATEL": [],
-            "MEANOFFNADIRVIEWANGLE": [],
-            "MEANINTRACKVIEWANGLE": [],
-            "MEANCROSSTRACKVIEWANGLE": [],
-            "MEANPRODUCTGSD": [],
-            "MEANSUNAZ": [],
-            "MEANSUNEL": [],
-            "CLOUDCOVER": [],
-            "geom": [],
-        }
-
-        for tag, lst in attributes.items():
-            if tag != "geom":
-                lst.append(get_xml_tag(xml, tag))
-            else:
-                # This returns a Shapely Polygon geometry
-                lst.append(self.xml2poly(xml))
-
-        d = {
-            "xml_fn": xml,
-            "catid": catid,
-            "sensor": get_xml_tag(xml, "SATID"),
-            "date": datetime.strptime(
-                get_xml_tag(xml, "FIRSTLINETIME"), "%Y-%m-%dT%H:%M:%S.%fZ"
-            ),
-            "scandir": get_xml_tag(xml, "SCANDIRECTION"),
-            "tdi": int(get_xml_tag(xml, "TDILEVEL")),
-            "geom": union_all(attributes["geom"]),
-        }
-
-        # Add Ephemeris GeoDataFrame, Attitude DataFrame, and Footprint GeoDataFrame
-        if geteph:
-            d["eph_gdf"] = self.getEphem_gdf(xml)
-            d["att_df"] = self.getAtt_df(xml)
-            d["fp_gdf"] = gpd.GeoDataFrame(
-                {"idx": [0], "geometry": d["geom"]},
-                geometry="geometry",
-                crs="EPSG:4326",
-            )
-
-        # Compute mean values when multiple xml make up a single image ID
-        for tag, lst in attributes.items():
-            if tag != "geom":
-                d[tag.lower()] = list_average(lst)
-
-        return d
-
-    def getEphem(self, xml):
-        """
-        Extract ephemeris data from XML file.
-
-        Retrieves satellite ephemeris (position and velocity) data from the XML file.
-
-        Parameters
-        ----------
-        xml : str
-            Path to the XML file
-
-        Returns
-        -------
-        numpy.ndarray
-            Array containing ephemeris data with columns:
-            point_num, Xpos, Ypos, Zpos, Xvel, Yvel, Zvel, and covariance matrix elements
-
-        Notes
-        -----
-        All coordinates are in Earth-Centered Fixed (ECF) reference frame.
-        Units are meters for positions, meters/sec for velocities, and m^2 for covariance.
-        """
-        e = get_xml_tag(xml, "EPHEMLIST", all=True)
-        # Could get fancy with structured array here
-        # point_num, Xpos, Ypos, Zpos, Xvel, Yvel, Zvel, covariance matrix (6 elements)
-        # dtype=[('point', 'i4'), ('Xpos', 'f8'), ('Ypos', 'f8'), ('Zpos', 'f8'), ('Xvel', 'f8') ...]
-        # All coordinates are ECF, meters, meters/sec, m^2
-        return np.array([i.split() for i in e], dtype=np.float64)
-
-    def getAtt(self, xml):
-        """
-        Extract attitude data from XML file.
-
-        Retrieves satellite attitude (orientation quaternion and covariance) data
-        from the XML file.
-
-        Parameters
-        ----------
-        xml : str
-            Path to the XML file
-
-        Returns
-        -------
-        numpy.ndarray
-            Array of shape (N, 15) containing attitude data with columns:
-            point_num, q1, q2, q3, q4, and 10 covariance matrix elements
-            (upper triangle of 4x4 matrix)
-        """
-        a = get_xml_tag(xml, "ATTLIST", all=True)
-        return np.array([i.split() for i in a], dtype=np.float64)
-
-    def getEphem_gdf(self, xml):
-        """
-        Create a GeoDataFrame from ephemeris data.
-
-        Converts ephemeris data to a GeoDataFrame with time index and Point geometry.
-
-        Parameters
-        ----------
-        xml : str
-            Path to the XML file
-
-        Returns
-        -------
-        geopandas.GeoDataFrame
-            GeoDataFrame with ephemeris data and Point geometries in EPSG:4978
-
-        Notes
-        -----
-        The GeoDataFrame uses EPSG:4978 (Earth-Centered Earth-Fixed) CRS and
-        has a time index corresponding to the acquisition times.
-        """
-        names = [
-            "index",
-        ]
-        names.extend(["x", "y", "z"])
-        names.extend(["dx", "dy", "dz"])
-        names.extend(["cov_{}".format(n) for n in ["11", "12", "13", "22", "23", "33"]])
-        e = self.getEphem(xml)
-        t0 = pd.to_datetime(get_xml_tag(xml, "STARTTIME"))
-        dt = pd.Timedelta(float(get_xml_tag(xml, "TIMEINTERVAL")), unit="s")
-        eph_df = pd.DataFrame(e, columns=names)
-        eph_df["time"] = t0 + eph_df.index * dt
-        eph_df.set_index("time", inplace=True)
-        eph_gdf = gpd.GeoDataFrame(
-            eph_df,
-            geometry=gpd.points_from_xy(eph_df["x"], eph_df["y"], eph_df["z"]),
-            crs="EPSG:4978",
-        )
-        return eph_gdf
-
-    def getAtt_df(self, xml):
-        """
-        Create a DataFrame from attitude data.
-
-        Converts attitude data to a DataFrame with time index.
-
-        Parameters
-        ----------
-        xml : str
-            Path to the XML file
-
-        Returns
-        -------
-        pandas.DataFrame
-            DataFrame with attitude quaternions and covariance, time-indexed
-        """
-        names = ["index", "q1", "q2", "q3", "q4"]
-        names.extend(
-            [
-                "cov_{}".format(n)
-                for n in ["11", "12", "13", "14", "22", "23", "24", "33", "34", "44"]
-            ]
-        )
-        a = self.getAtt(xml)
-        t0 = pd.to_datetime(get_xml_tag(xml, "STARTTIME"))
-        dt = pd.Timedelta(float(get_xml_tag(xml, "TIMEINTERVAL")), unit="s")
-        att_df = pd.DataFrame(a, columns=names)
-        att_df["time"] = t0 + att_df.index * dt
-        att_df.set_index("time", inplace=True)
-        return att_df
-
-    def xml2wkt(self, xml):
-        """
-        Convert XML corner coordinates to WKT polygon string.
-
-        Extracts corner coordinates from XML file and converts them to a
-        Well-Known Text (WKT) polygon string.
-
-        Parameters
-        ----------
-        xml : str
-            Path to the XML file
-
-        Returns
-        -------
-        str
-            WKT polygon string representation of image footprint
-
-        Notes
-        -----
-        Uses ULLON/ULLAT, URLON/URLAT, LRLON/LRLAT, LLLON/LLLAT tags
-        (Upper-Left, Upper-Right, Lower-Right, Lower-Left corners).
-        """
-        tags = [
-            ("ULLON", "ULLAT"),
-            ("URLON", "URLAT"),
-            ("LRLON", "LRLAT"),
-            ("LLLON", "LLLAT"),
-            ("ULLON", "ULLAT"),
-        ]
-        coords = []
-        for lon_tag, lat_tag in tags:
-            lon = get_xml_tag(xml, lon_tag)
-            lat = get_xml_tag(xml, lat_tag)
-            if lon and lat:
-                coords.append(f"{lon} {lat}")
-        geom_wkt = f"POLYGON(({', '.join(coords)}))"
-        return geom_wkt
-
-    def xml2poly(self, xml):
-        """
-        Convert XML corner coordinates to Shapely Polygon.
-
-        Reads XML file and converts corner coordinates to a Shapely Polygon geometry.
-
-        Parameters
-        ----------
-        xml : str
-            Path to the XML file
-
-        Returns
-        -------
-        shapely.geometry.Polygon
-            Polygon geometry representing the image footprint
-        """
-        geom_wkt = self.xml2wkt(xml)
-        return wkt.loads(geom_wkt)
+        return self.reader.get_scene_dicts()
 
     def pair_dict(self, catid1_dict, catid2_dict, pairname):
         def center_date(dt_list):

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -55,8 +55,8 @@ class TestImports:
         from asp_plot.selections import FigureSelections
         from asp_plot.sensors import (
             SENSORS,
-            DigitalGlobeMetadata,
             SensorMetadata,
+            WorldViewMetadata,
             sensor_for_directory,
         )
         from asp_plot.stereo import StereoPlotter
@@ -84,6 +84,6 @@ class TestImports:
         assert BODIES is not None
         assert body_for_dem is not None
         assert SensorMetadata is not None
-        assert DigitalGlobeMetadata is not None
+        assert WorldViewMetadata is not None
         assert SENSORS is not None
         assert sensor_for_directory is not None

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -22,6 +22,7 @@ class TestImports:
         import asp_plot.report_pipeline
         import asp_plot.scenes
         import asp_plot.selections
+        import asp_plot.sensors
         import asp_plot.stereo_geometry
         import asp_plot.stereopair_metadata_parser
         import asp_plot.utils
@@ -40,6 +41,7 @@ class TestImports:
         assert asp_plot.altimetry is not None
         assert asp_plot.alignment is not None
         assert asp_plot.bodies is not None
+        assert asp_plot.sensors is not None
 
     def test_import_asp_plot_classes(self):
         from asp_plot.alignment import Alignment
@@ -51,6 +53,12 @@ class TestImports:
         from asp_plot.report_pipeline import ReportConfig, run_report
         from asp_plot.scenes import ScenePlotter
         from asp_plot.selections import FigureSelections
+        from asp_plot.sensors import (
+            SENSORS,
+            DigitalGlobeMetadata,
+            SensorMetadata,
+            sensor_for_directory,
+        )
         from asp_plot.stereo import StereoPlotter
         from asp_plot.stereo_geometry import StereoGeometryPlotter
         from asp_plot.stereopair_metadata_parser import StereopairMetadataParser
@@ -75,3 +83,7 @@ class TestImports:
         assert Body is not None
         assert BODIES is not None
         assert body_for_dem is not None
+        assert SensorMetadata is not None
+        assert DigitalGlobeMetadata is not None
+        assert SENSORS is not None
+        assert sensor_for_directory is not None

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -1,0 +1,96 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from asp_plot.sensors import (
+    SENSORS,
+    DigitalGlobeMetadata,
+    SensorMetadata,
+    sensor_for_directory,
+)
+
+
+class TestDigitalGlobeMetadata:
+    @pytest.fixture
+    def reader(self):
+        return DigitalGlobeMetadata(directory="tests/test_data")
+
+    @pytest.fixture
+    def reader_tiled(self):
+        return DigitalGlobeMetadata(directory="tests/test_data/tiled_xmls")
+
+    def test_is_sensor_metadata(self, reader):
+        assert isinstance(reader, SensorMetadata)
+        assert reader.name == "DigitalGlobe/Maxar"
+
+    def test_image_list_excludes_ortho(self, reader):
+        assert len(reader.image_list) > 0
+        assert all(not f.lower().endswith("ortho.xml") for f in reader.image_list)
+        assert all(f.lower().endswith(".xml") for f in reader.image_list)
+
+    def test_missing_xml_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="Missing XML camera files"):
+            DigitalGlobeMetadata(directory=str(tmp_path))
+
+    def test_get_scene_dicts(self, reader):
+        scene_dicts = reader.get_scene_dicts()
+        assert isinstance(scene_dicts, list)
+        assert len(scene_dicts) == 2
+        for d in scene_dicts:
+            for key in ["catid", "sensor", "date", "geom", "meansataz", "meansatel"]:
+                assert key in d
+
+    def test_att_df_in_scene_dict(self, reader):
+        for d in reader.get_scene_dicts():
+            assert "att_df" in d
+            assert isinstance(d["att_df"], pd.DataFrame)
+            assert len(d["att_df"]) > 0
+
+    def test_getAtt(self, reader):
+        xml = reader.image_list[0]
+        att = reader.getAtt(xml)
+        assert isinstance(att, np.ndarray)
+        assert att.dtype == np.float64
+        assert att.shape == (3, 15)
+
+    def test_getAtt_df(self, reader):
+        xml = reader.image_list[0]
+        att_df = reader.getAtt_df(xml)
+        assert isinstance(att_df, pd.DataFrame)
+        assert isinstance(att_df.index, pd.DatetimeIndex)
+        for col in ["q1", "q2", "q3", "q4"]:
+            assert col in att_df.columns
+        for n in ["11", "12", "13", "14", "22", "23", "24", "33", "34", "44"]:
+            assert f"cov_{n}" in att_df.columns
+
+    def test_getEphem_gdf_covariance_columns(self, reader):
+        xml = reader.image_list[0]
+        eph_gdf = reader.getEphem_gdf(xml)
+        for n in ["11", "12", "13", "22", "23", "33"]:
+            assert f"cov_{n}" in eph_gdf.columns
+        for old_name in ["x_cov", "y_cov", "z_cov", "dx_cov", "dy_cov", "dz_cov"]:
+            assert old_name not in eph_gdf.columns
+
+    def test_get_scene_dicts_tiled(self, reader_tiled):
+        scene_dicts = reader_tiled.get_scene_dicts()
+        assert len(scene_dicts) == 2
+
+
+class TestSensorDetection:
+    def test_detect_digitalglobe(self):
+        assert DigitalGlobeMetadata.detect("tests/test_data") is True
+
+    def test_detect_empty_dir(self, tmp_path):
+        assert DigitalGlobeMetadata.detect(str(tmp_path)) is False
+
+    def test_registry_contains_digitalglobe(self):
+        assert DigitalGlobeMetadata in SENSORS
+
+    def test_sensor_for_directory_returns_reader(self):
+        reader = sensor_for_directory("tests/test_data")
+        assert isinstance(reader, DigitalGlobeMetadata)
+        assert isinstance(reader, SensorMetadata)
+
+    def test_sensor_for_directory_no_match_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="No supported sensor metadata"):
+            sensor_for_directory(str(tmp_path))

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -4,24 +4,24 @@ import pytest
 
 from asp_plot.sensors import (
     SENSORS,
-    DigitalGlobeMetadata,
     SensorMetadata,
+    WorldViewMetadata,
     sensor_for_directory,
 )
 
 
-class TestDigitalGlobeMetadata:
+class TestWorldViewMetadata:
     @pytest.fixture
     def reader(self):
-        return DigitalGlobeMetadata(directory="tests/test_data")
+        return WorldViewMetadata(directory="tests/test_data")
 
     @pytest.fixture
     def reader_tiled(self):
-        return DigitalGlobeMetadata(directory="tests/test_data/tiled_xmls")
+        return WorldViewMetadata(directory="tests/test_data/tiled_xmls")
 
     def test_is_sensor_metadata(self, reader):
         assert isinstance(reader, SensorMetadata)
-        assert reader.name == "DigitalGlobe/Maxar"
+        assert reader.name == "WorldView"
 
     def test_image_list_excludes_ortho(self, reader):
         assert len(reader.image_list) > 0
@@ -30,7 +30,7 @@ class TestDigitalGlobeMetadata:
 
     def test_missing_xml_raises(self, tmp_path):
         with pytest.raises(ValueError, match="Missing XML camera files"):
-            DigitalGlobeMetadata(directory=str(tmp_path))
+            WorldViewMetadata(directory=str(tmp_path))
 
     def test_get_scene_dicts(self, reader):
         scene_dicts = reader.get_scene_dicts()
@@ -77,18 +77,18 @@ class TestDigitalGlobeMetadata:
 
 
 class TestSensorDetection:
-    def test_detect_digitalglobe(self):
-        assert DigitalGlobeMetadata.detect("tests/test_data") is True
+    def test_detect_worldview(self):
+        assert WorldViewMetadata.detect("tests/test_data") is True
 
     def test_detect_empty_dir(self, tmp_path):
-        assert DigitalGlobeMetadata.detect(str(tmp_path)) is False
+        assert WorldViewMetadata.detect(str(tmp_path)) is False
 
-    def test_registry_contains_digitalglobe(self):
-        assert DigitalGlobeMetadata in SENSORS
+    def test_registry_contains_worldview(self):
+        assert WorldViewMetadata in SENSORS
 
     def test_sensor_for_directory_returns_reader(self):
         reader = sensor_for_directory("tests/test_data")
-        assert isinstance(reader, DigitalGlobeMetadata)
+        assert isinstance(reader, WorldViewMetadata)
         assert isinstance(reader, SensorMetadata)
 
     def test_sensor_for_directory_no_match_raises(self, tmp_path):

--- a/tests/test_stereo_geometry.py
+++ b/tests/test_stereo_geometry.py
@@ -1,15 +1,8 @@
 import matplotlib
-import numpy as np
-import pandas as pd
 import pytest
 
 from asp_plot.stereo_geometry import StereoGeometryPlotter
-from asp_plot.stereopair_metadata_parser import (
-    get_asymmetry_angle,
-    get_bh_ratio,
-    get_bie_angle,
-    get_convergence_angle,
-)
+from asp_plot.stereopair_metadata_parser import StereopairMetadataParser
 
 matplotlib.use("Agg")
 
@@ -29,44 +22,16 @@ class TestStereoGeometryPlotter:
         )
         return stereo_geometry_plotter
 
+    def test_composes_parser_not_inherits(self, stereo_geometry_plotter):
+        # The plotter should compose a parser rather than inherit from it
+        assert not isinstance(stereo_geometry_plotter, StereopairMetadataParser)
+        assert isinstance(stereo_geometry_plotter.parser, StereopairMetadataParser)
+
     def test_dg_geom_plot(self, stereo_geometry_plotter):
         try:
             stereo_geometry_plotter.dg_geom_plot()
         except Exception as e:
             pytest.fail(f"figure method raised an exception: {str(e)}")
-
-    def test_get_pair_utm_epsg(self, stereo_geometry_plotter):
-        utm_epsg = stereo_geometry_plotter.get_pair_utm_epsg()
-        assert isinstance(utm_epsg, int)
-        assert 32601 <= utm_epsg <= 32760
-
-    def test_get_intersection_bounds_latlon(self, stereo_geometry_plotter):
-        bounds = stereo_geometry_plotter.get_intersection_bounds()
-        assert len(bounds) == 4
-        min_lon, min_lat, max_lon, max_lat = bounds
-        assert min_lon < max_lon
-        assert min_lat < max_lat
-        assert -180 <= min_lon <= 180
-        assert -90 <= min_lat <= 90
-
-    def test_get_intersection_bounds_projected(self, stereo_geometry_plotter):
-        utm_epsg = stereo_geometry_plotter.get_pair_utm_epsg()
-        bounds = stereo_geometry_plotter.get_intersection_bounds(epsg=utm_epsg)
-        min_x, min_y, max_x, max_y = bounds
-        assert min_x < max_x
-        assert min_y < max_y
-        # UTM easting/northing should be large values (not lon/lat)
-        assert min_x > 100000
-
-    def test_get_scene_bounds(self, stereo_geometry_plotter):
-        bounds = stereo_geometry_plotter.get_scene_bounds()
-        assert len(bounds) == 4
-        min_lon, min_lat, max_lon, max_lat = bounds
-        assert min_lon < max_lon
-        assert min_lat < max_lat
-        # Bounds should be valid lon/lat
-        assert -180 <= min_lon <= 180
-        assert -90 <= min_lat <= 90
 
     def test_dg_geom_plot_tiled(self, stereo_geometry_plotter_tiled):
         try:
@@ -74,209 +39,8 @@ class TestStereoGeometryPlotter:
         except Exception as e:
             pytest.fail(f"figure method raised an exception: {str(e)}")
 
-    def test_getAtt(self, stereo_geometry_plotter):
-        xml = stereo_geometry_plotter.image_list[0]
-        att = stereo_geometry_plotter.getAtt(xml)
-        assert isinstance(att, np.ndarray)
-        assert att.dtype == np.float64
-        assert att.shape == (3, 15)
-
-    def test_getAtt_df(self, stereo_geometry_plotter):
-        xml = stereo_geometry_plotter.image_list[0]
-        att_df = stereo_geometry_plotter.getAtt_df(xml)
-        assert isinstance(att_df, pd.DataFrame)
-        assert isinstance(att_df.index, pd.DatetimeIndex)
-        for col in ["q1", "q2", "q3", "q4"]:
-            assert col in att_df.columns
-        for n in ["11", "12", "13", "14", "22", "23", "24", "33", "34", "44"]:
-            assert f"cov_{n}" in att_df.columns
-
-    def test_getEphem_gdf_covariance_columns(self, stereo_geometry_plotter):
-        xml = stereo_geometry_plotter.image_list[0]
-        eph_gdf = stereo_geometry_plotter.getEphem_gdf(xml)
-        for n in ["11", "12", "13", "22", "23", "33"]:
-            assert f"cov_{n}" in eph_gdf.columns
-        for old_name in ["x_cov", "y_cov", "z_cov", "dx_cov", "dy_cov", "dz_cov"]:
-            assert old_name not in eph_gdf.columns
-
-    def test_att_df_in_catid_dict(self, stereo_geometry_plotter):
-        catid_dicts = stereo_geometry_plotter.get_catid_dicts()
-        for d in catid_dicts:
-            assert "att_df" in d
-            assert isinstance(d["att_df"], pd.DataFrame)
-            assert len(d["att_df"]) > 0
-
     def test_satellite_position_orientation_plot(self, stereo_geometry_plotter):
         try:
             stereo_geometry_plotter.satellite_position_orientation_plot()
         except Exception as e:
             pytest.fail(f"figure method raised an exception: {str(e)}")
-
-    def test_pair_dict_stereo_geometry_values(self, stereo_geometry_plotter):
-        """Test stereo geometry values from real XML test data."""
-        p = stereo_geometry_plotter.get_pair_dict()
-
-        # All geometry keys should be present
-        for key in ["conv_ang", "bh", "bie", "asymmetry_angle"]:
-            assert key in p
-
-        # Convergence angle: positive, reasonable for VHR stereo
-        assert 0 < p["conv_ang"] < 90
-
-        # B/H ratio: consistent with convergence angle
-        assert p["bh"] == get_bh_ratio(p["conv_ang"])
-
-        # BIE: positive, less than 90
-        assert 0 < p["bie"] < 90
-
-        # Asymmetry angle: non-negative and less than convergence angle
-        assert 0 <= p["asymmetry_angle"] < p["conv_ang"]
-
-        # Verify convergence matches direct computation from XML az/el
-        az1, el1 = p["catid1_dict"]["meansataz"], p["catid1_dict"]["meansatel"]
-        az2, el2 = p["catid2_dict"]["meansataz"], p["catid2_dict"]["meansatel"]
-        assert p["conv_ang"] == get_convergence_angle(az1, el1, az2, el2)
-        assert p["bie"] == get_bie_angle(az1, el1, az2, el2)
-
-    def test_pair_dict_stereo_geometry_values_tiled(
-        self, stereo_geometry_plotter_tiled
-    ):
-        """Test stereo geometry values from tiled XML test data."""
-        p = stereo_geometry_plotter_tiled.get_pair_dict()
-
-        for key in ["conv_ang", "bh", "bie", "asymmetry_angle"]:
-            assert key in p
-
-        assert 0 < p["conv_ang"] < 90
-        assert 0 < p["bie"] < 90
-        assert 0 <= p["asymmetry_angle"] < p["conv_ang"]
-
-
-class TestStereoGeometryCalculations:
-    """Direct tests for stereo geometry formulas (convergence, BIE, asymmetry).
-
-    References:
-        Jeong & Kim (2014), PE&RS 80(7), 653-662
-        Jeong & Kim (2016), PE&RS 82(8), 625-633
-    """
-
-    def test_convergence_identical_directions(self):
-        """Same viewing direction should give zero convergence."""
-        conv = get_convergence_angle(az1=180, el1=75, az2=180, el2=75)
-        assert conv == pytest.approx(0.0, abs=1e-10)
-
-    def test_convergence_opposite_azimuths(self):
-        """Symmetric pair at same elevation, 180 deg apart in azimuth."""
-        conv = get_convergence_angle(az1=0, el1=70, az2=180, el2=70)
-        # Off-nadir = 20 deg each, opposite sides -> convergence = 2 * off-nadir = 40
-        assert conv == pytest.approx(40.0, abs=0.01)
-
-    def test_convergence_symmetric_small_offset(self):
-        """Two views at same elevation, small azimuth difference."""
-        conv = get_convergence_angle(az1=170, el1=80, az2=190, el2=80)
-        assert 0 < conv < 20  # small convergence
-
-    def test_bh_from_convergence(self):
-        """B/H = 2*tan(conv/2), verified for known convergence angles."""
-        for conv in [10, 20, 30, 45, 60]:
-            bh = get_bh_ratio(conv)
-            assert bh == pytest.approx(2 * np.tan(np.deg2rad(conv / 2.0)), abs=0.01)
-
-    def test_bie_symmetric_pair(self):
-        """Symmetric pair with opposite azimuths: bisector is vertical, BIE = 90."""
-        bie = get_bie_angle(az1=0, el1=75, az2=180, el2=75)
-        assert bie == pytest.approx(90.0, abs=0.01)
-
-    def test_bie_nadir(self):
-        """Both views near-nadir with opposite azimuths: BIE = 90."""
-        bie = get_bie_angle(az1=0, el1=89, az2=180, el2=89)
-        assert bie == pytest.approx(90.0, abs=0.01)
-
-    def test_bie_range(self):
-        """BIE should be between 0 and 90 for any valid geometry."""
-        for az1, el1, az2, el2 in [
-            (45, 60, 225, 70),
-            (90, 80, 270, 65),
-            (10, 50, 200, 85),
-        ]:
-            bie = get_bie_angle(az1, el1, az2, el2)
-            assert 0 < bie < 90
-
-    def test_asymmetry_symmetric_pair(self):
-        """Symmetric geometry about nadir should give asymmetry near zero."""
-        # Place two satellites symmetrically about a ground point on the equator
-        # Ground point on equator at lon=0: ECEF = (R, 0, 0)
-        R_earth = 6.371e6
-        alt = 770e3  # ~770 km orbit
-        ground = np.array([R_earth, 0, 0])
-        # Two sats symmetric in the x-z plane, offset by equal angles
-        angle = np.deg2rad(15)
-        sat1 = np.array(
-            [(R_earth + alt) * np.cos(angle), 0, (R_earth + alt) * np.sin(angle)]
-        )
-        sat2 = np.array(
-            [(R_earth + alt) * np.cos(angle), 0, -(R_earth + alt) * np.sin(angle)]
-        )
-        asym = get_asymmetry_angle(sat1, sat2, ground)
-        assert asym == pytest.approx(0.0, abs=0.5)
-
-    def test_asymmetry_less_than_convergence(self):
-        """For typical near-nadir geometry, asymmetry should be < convergence."""
-        R_earth = 6.371e6
-        alt = 770e3
-        ground = np.array([R_earth, 0, 0])
-        # Asymmetric pair: one near-nadir, one more off-nadir
-        sat1 = np.array(
-            [
-                (R_earth + alt) * np.cos(np.deg2rad(5)),
-                0,
-                (R_earth + alt) * np.sin(np.deg2rad(5)),
-            ]
-        )
-        sat2 = np.array(
-            [
-                (R_earth + alt) * np.cos(np.deg2rad(20)),
-                0,
-                -(R_earth + alt) * np.sin(np.deg2rad(20)),
-            ]
-        )
-        asym = get_asymmetry_angle(sat1, sat2, ground)
-        # Compute convergence from the same geometry
-        q1 = ground - sat1
-        q1 = q1 / np.linalg.norm(q1)
-        q2 = ground - sat2
-        q2 = q2 / np.linalg.norm(q2)
-        conv = np.rad2deg(np.arccos(np.clip(np.dot(q1, q2), -1, 1)))
-        assert asym < conv
-        assert asym > 0
-
-    def test_asymmetry_ground_point_z_matters(self):
-        """Verify that correct ECEF z-coordinate affects the asymmetry angle.
-
-        This tests the bug fix: setting ECEF z=0 (equatorial plane) instead of
-        using the proper ellipsoid height gives wrong results at high latitudes.
-        """
-        from pyproj import Transformer
-
-        alt = 770e3
-
-        # Ground point at ~60N latitude -- large ECEF z
-        transformer = Transformer.from_crs("EPSG:4326", "EPSG:4978", always_xy=True)
-        ground_correct = np.array(transformer.transform(10.0, 60.0, 0.0))
-
-        # Buggy version: zero out ECEF z
-        ground_buggy = np.array([ground_correct[0], ground_correct[1], 0.0])
-
-        # Satellites roughly overhead
-        sat1 = np.array(
-            [ground_correct[0] + alt * 0.1, ground_correct[1], ground_correct[2] + alt]
-        )
-        sat2 = np.array(
-            [ground_correct[0] - alt * 0.1, ground_correct[1], ground_correct[2] + alt]
-        )
-
-        asym_correct = get_asymmetry_angle(sat1, sat2, ground_correct)
-        asym_buggy = get_asymmetry_angle(sat1, sat2, ground_buggy)
-
-        # The two should differ significantly at 60N
-        assert abs(asym_correct - asym_buggy) > 1.0

--- a/tests/test_stereopair_metadata_parser.py
+++ b/tests/test_stereopair_metadata_parser.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from asp_plot.sensors import DigitalGlobeMetadata
+from asp_plot.sensors import WorldViewMetadata
 from asp_plot.stereopair_metadata_parser import (
     StereopairMetadataParser,
     get_asymmetry_angle,
@@ -23,7 +23,7 @@ class TestStereopairMetadataParser:
 
     def test_detects_sensor_reader(self, parser):
         # Parser is sensor-agnostic and delegates to a detected reader
-        assert isinstance(parser.reader, DigitalGlobeMetadata)
+        assert isinstance(parser.reader, WorldViewMetadata)
 
     def test_image_list_delegates_to_reader(self, parser):
         assert parser.image_list is parser.reader.image_list

--- a/tests/test_stereopair_metadata_parser.py
+++ b/tests/test_stereopair_metadata_parser.py
@@ -1,0 +1,241 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from asp_plot.sensors import DigitalGlobeMetadata
+from asp_plot.stereopair_metadata_parser import (
+    StereopairMetadataParser,
+    get_asymmetry_angle,
+    get_bh_ratio,
+    get_bie_angle,
+    get_convergence_angle,
+)
+
+
+class TestStereopairMetadataParser:
+    @pytest.fixture
+    def parser(self):
+        return StereopairMetadataParser(directory="tests/test_data")
+
+    @pytest.fixture
+    def parser_tiled(self):
+        return StereopairMetadataParser(directory="tests/test_data/tiled_xmls")
+
+    def test_detects_sensor_reader(self, parser):
+        # Parser is sensor-agnostic and delegates to a detected reader
+        assert isinstance(parser.reader, DigitalGlobeMetadata)
+
+    def test_image_list_delegates_to_reader(self, parser):
+        assert parser.image_list is parser.reader.image_list
+        assert len(parser.image_list) > 0
+
+    def test_missing_metadata_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="No supported sensor metadata"):
+            StereopairMetadataParser(directory=str(tmp_path))
+
+    def test_get_pair_utm_epsg(self, parser):
+        utm_epsg = parser.get_pair_utm_epsg()
+        assert isinstance(utm_epsg, int)
+        assert 32601 <= utm_epsg <= 32760
+
+    def test_get_intersection_bounds_latlon(self, parser):
+        bounds = parser.get_intersection_bounds()
+        assert len(bounds) == 4
+        min_lon, min_lat, max_lon, max_lat = bounds
+        assert min_lon < max_lon
+        assert min_lat < max_lat
+        assert -180 <= min_lon <= 180
+        assert -90 <= min_lat <= 90
+
+    def test_get_intersection_bounds_projected(self, parser):
+        utm_epsg = parser.get_pair_utm_epsg()
+        bounds = parser.get_intersection_bounds(epsg=utm_epsg)
+        min_x, min_y, max_x, max_y = bounds
+        assert min_x < max_x
+        assert min_y < max_y
+        # UTM easting/northing should be large values (not lon/lat)
+        assert min_x > 100000
+
+    def test_get_scene_bounds(self, parser):
+        bounds = parser.get_scene_bounds()
+        assert len(bounds) == 4
+        min_lon, min_lat, max_lon, max_lat = bounds
+        assert min_lon < max_lon
+        assert min_lat < max_lat
+        # Bounds should be valid lon/lat
+        assert -180 <= min_lon <= 180
+        assert -90 <= min_lat <= 90
+
+    def test_att_df_in_catid_dict(self, parser):
+        catid_dicts = parser.get_catid_dicts()
+        for d in catid_dicts:
+            assert "att_df" in d
+            assert isinstance(d["att_df"], pd.DataFrame)
+            assert len(d["att_df"]) > 0
+
+    def test_pair_dict_stereo_geometry_values(self, parser):
+        """Test stereo geometry values from real XML test data."""
+        p = parser.get_pair_dict()
+
+        # All geometry keys should be present
+        for key in ["conv_ang", "bh", "bie", "asymmetry_angle"]:
+            assert key in p
+
+        # Convergence angle: positive, reasonable for VHR stereo
+        assert 0 < p["conv_ang"] < 90
+
+        # B/H ratio: consistent with convergence angle
+        assert p["bh"] == get_bh_ratio(p["conv_ang"])
+
+        # BIE: positive, less than 90
+        assert 0 < p["bie"] < 90
+
+        # Asymmetry angle: non-negative and less than convergence angle
+        assert 0 <= p["asymmetry_angle"] < p["conv_ang"]
+
+        # Verify convergence matches direct computation from XML az/el
+        az1, el1 = p["catid1_dict"]["meansataz"], p["catid1_dict"]["meansatel"]
+        az2, el2 = p["catid2_dict"]["meansataz"], p["catid2_dict"]["meansatel"]
+        assert p["conv_ang"] == get_convergence_angle(az1, el1, az2, el2)
+        assert p["bie"] == get_bie_angle(az1, el1, az2, el2)
+
+    def test_pair_dict_stereo_geometry_values_tiled(self, parser_tiled):
+        """Test stereo geometry values from tiled XML test data."""
+        p = parser_tiled.get_pair_dict()
+
+        for key in ["conv_ang", "bh", "bie", "asymmetry_angle"]:
+            assert key in p
+
+        assert 0 < p["conv_ang"] < 90
+        assert 0 < p["bie"] < 90
+        assert 0 <= p["asymmetry_angle"] < p["conv_ang"]
+
+
+class TestStereoGeometryCalculations:
+    """Direct tests for stereo geometry formulas (convergence, BIE, asymmetry).
+
+    References:
+        Jeong & Kim (2014), PE&RS 80(7), 653-662
+        Jeong & Kim (2016), PE&RS 82(8), 625-633
+    """
+
+    def test_convergence_identical_directions(self):
+        """Same viewing direction should give zero convergence."""
+        conv = get_convergence_angle(az1=180, el1=75, az2=180, el2=75)
+        assert conv == pytest.approx(0.0, abs=1e-10)
+
+    def test_convergence_opposite_azimuths(self):
+        """Symmetric pair at same elevation, 180 deg apart in azimuth."""
+        conv = get_convergence_angle(az1=0, el1=70, az2=180, el2=70)
+        # Off-nadir = 20 deg each, opposite sides -> convergence = 2 * off-nadir = 40
+        assert conv == pytest.approx(40.0, abs=0.01)
+
+    def test_convergence_symmetric_small_offset(self):
+        """Two views at same elevation, small azimuth difference."""
+        conv = get_convergence_angle(az1=170, el1=80, az2=190, el2=80)
+        assert 0 < conv < 20  # small convergence
+
+    def test_bh_from_convergence(self):
+        """B/H = 2*tan(conv/2), verified for known convergence angles."""
+        for conv in [10, 20, 30, 45, 60]:
+            bh = get_bh_ratio(conv)
+            assert bh == pytest.approx(2 * np.tan(np.deg2rad(conv / 2.0)), abs=0.01)
+
+    def test_bie_symmetric_pair(self):
+        """Symmetric pair with opposite azimuths: bisector is vertical, BIE = 90."""
+        bie = get_bie_angle(az1=0, el1=75, az2=180, el2=75)
+        assert bie == pytest.approx(90.0, abs=0.01)
+
+    def test_bie_nadir(self):
+        """Both views near-nadir with opposite azimuths: BIE = 90."""
+        bie = get_bie_angle(az1=0, el1=89, az2=180, el2=89)
+        assert bie == pytest.approx(90.0, abs=0.01)
+
+    def test_bie_range(self):
+        """BIE should be between 0 and 90 for any valid geometry."""
+        for az1, el1, az2, el2 in [
+            (45, 60, 225, 70),
+            (90, 80, 270, 65),
+            (10, 50, 200, 85),
+        ]:
+            bie = get_bie_angle(az1, el1, az2, el2)
+            assert 0 < bie < 90
+
+    def test_asymmetry_symmetric_pair(self):
+        """Symmetric geometry about nadir should give asymmetry near zero."""
+        # Place two satellites symmetrically about a ground point on the equator
+        # Ground point on equator at lon=0: ECEF = (R, 0, 0)
+        R_earth = 6.371e6
+        alt = 770e3  # ~770 km orbit
+        ground = np.array([R_earth, 0, 0])
+        # Two sats symmetric in the x-z plane, offset by equal angles
+        angle = np.deg2rad(15)
+        sat1 = np.array(
+            [(R_earth + alt) * np.cos(angle), 0, (R_earth + alt) * np.sin(angle)]
+        )
+        sat2 = np.array(
+            [(R_earth + alt) * np.cos(angle), 0, -(R_earth + alt) * np.sin(angle)]
+        )
+        asym = get_asymmetry_angle(sat1, sat2, ground)
+        assert asym == pytest.approx(0.0, abs=0.5)
+
+    def test_asymmetry_less_than_convergence(self):
+        """For typical near-nadir geometry, asymmetry should be < convergence."""
+        R_earth = 6.371e6
+        alt = 770e3
+        ground = np.array([R_earth, 0, 0])
+        # Asymmetric pair: one near-nadir, one more off-nadir
+        sat1 = np.array(
+            [
+                (R_earth + alt) * np.cos(np.deg2rad(5)),
+                0,
+                (R_earth + alt) * np.sin(np.deg2rad(5)),
+            ]
+        )
+        sat2 = np.array(
+            [
+                (R_earth + alt) * np.cos(np.deg2rad(20)),
+                0,
+                -(R_earth + alt) * np.sin(np.deg2rad(20)),
+            ]
+        )
+        asym = get_asymmetry_angle(sat1, sat2, ground)
+        # Compute convergence from the same geometry
+        q1 = ground - sat1
+        q1 = q1 / np.linalg.norm(q1)
+        q2 = ground - sat2
+        q2 = q2 / np.linalg.norm(q2)
+        conv = np.rad2deg(np.arccos(np.clip(np.dot(q1, q2), -1, 1)))
+        assert asym < conv
+        assert asym > 0
+
+    def test_asymmetry_ground_point_z_matters(self):
+        """Verify that correct ECEF z-coordinate affects the asymmetry angle.
+
+        This tests the bug fix: setting ECEF z=0 (equatorial plane) instead of
+        using the proper ellipsoid height gives wrong results at high latitudes.
+        """
+        from pyproj import Transformer
+
+        alt = 770e3
+
+        # Ground point at ~60N latitude -- large ECEF z
+        transformer = Transformer.from_crs("EPSG:4326", "EPSG:4978", always_xy=True)
+        ground_correct = np.array(transformer.transform(10.0, 60.0, 0.0))
+
+        # Buggy version: zero out ECEF z
+        ground_buggy = np.array([ground_correct[0], ground_correct[1], 0.0])
+
+        # Satellites roughly overhead
+        sat1 = np.array(
+            [ground_correct[0] + alt * 0.1, ground_correct[1], ground_correct[2] + alt]
+        )
+        sat2 = np.array(
+            [ground_correct[0] - alt * 0.1, ground_correct[1], ground_correct[2] + alt]
+        )
+
+        asym_correct = get_asymmetry_angle(sat1, sat2, ground_correct)
+        asym_buggy = get_asymmetry_angle(sat1, sat2, ground_buggy)
+
+        # The two should differ significantly at 60N
+        assert abs(asym_correct - asym_buggy) > 1.0


### PR DESCRIPTION
Closes #25 (sub-issue of #122).

## What

Separates the **sensor-specific** work of discovering scene files and extracting per-scene metadata from the **sensor-agnostic** stereo-pair geometry math, and makes `StereoGeometryPlotter` **compose** a parser instead of inheriting from it. This is the original motivating issue for the structural rewrite: the metadata/geometry code was tightly coupled to DigitalGlobe/Maxar WV scenes with no seam for ASTER, HiRISE, etc.

## Changes

**New `asp_plot/sensors.py`** (mirrors the `bodies.py` pattern from #126):
- `SensorMetadata` ABC defining the reader interface (`detect()` + `get_scene_dicts()`) and documenting the sensor-agnostic *scene-dict* schema the geometry code consumes.
- `DigitalGlobeMetadata(SensorMetadata)` — the existing DigitalGlobe/Maxar XML logic (file discovery, `dg_mosaic` tiling, per-scene extraction, ephemeris/attitude/footprint) moved **verbatim** out of the parser.
- `SENSORS` registry + `sensor_for_directory()` auto-detection. Adding a new sensor is now a new `SensorMetadata` subclass — **no changes to the pair-level geometry code**.

**`stereopair_metadata_parser.py`** is now a sensor-agnostic orchestrator: it detects a reader, delegates scene extraction to it, and keeps only the pair-level geometry (convergence / B:H / BIE / asymmetry, footprint intersection, bounds, UTM EPSG). `image_list` is delegated to the reader.

**`stereo_geometry.py`**: `StereoGeometryPlotter` no longer subclasses `StereopairMetadataParser` — it holds `self.parser` and accesses metadata through it (compose, not inherit).

**Tests** reorganized to mirror the module split:
- New `test_sensors.py` — reader behavior + sensor detection/registry.
- New `test_stereopair_metadata_parser.py` — pair-level geometry, bounds, and the formula tests.
- `test_stereo_geometry.py` trimmed to plotting + a composition-wiring assertion.
- `test_imports.py` updated for the new module/exports.

## Scope note

Per issue #25, full multi-sensor support "requires a case-by-case study of metadata for each product ... done iteratively at a later point." This PR establishes the **extension seam** (and detection) with DigitalGlobe/Maxar as the one implemented reader — the only sensor we have test data for. A future ASTER/HiRISE reader plugs in without touching the geometry layer.

## Behavior

Pure internal refactor — no change to outputs or the public surface used by `report_pipeline`/`bundle_adjust`/`altimetry` (all go through `parser.get_pair_dict()`). Full suite green: **252 passed**. DG XML parsing methods were moved without modification.