### PR TITLE
Give Plotter a real scaffold + separate file discovery from plotting (#129)

### DIFF
--- a/asp_plot/bundle_adjust.py
+++ b/asp_plot/bundle_adjust.py
@@ -8,13 +8,7 @@ import pandas as pd
 
 from asp_plot.processing_parameters import ProcessingParameters
 from asp_plot.stereopair_metadata_parser import StereopairMetadataParser
-from asp_plot.utils import (
-    ColorBar,
-    Plotter,
-    glob_file,
-    run_subprocess_command,
-    save_figure,
-)
+from asp_plot.utils import ColorBar, Plotter, glob_file, run_subprocess_command
 
 logging.basicConfig(level=logging.WARNING)
 logger = logging.getLogger(__name__)
@@ -637,6 +631,4 @@ class PlotBundleAdjustFiles(Plotter):
             fig.delaxes(axa[i])
         fig.suptitle(self.title, size=10)
         plt.subplots_adjust(wspace=0.2, hspace=0.4)
-        fig.tight_layout()
-        if save_dir and fig_fn:
-            save_figure(fig, save_dir, fig_fn)
+        self.save(fig, save_dir, fig_fn)

--- a/asp_plot/gallery.py
+++ b/asp_plot/gallery.py
@@ -4,9 +4,8 @@ import os
 
 import matplotlib.pyplot as plt
 import numpy as np
-from osgeo import gdal
 
-from asp_plot.utils import Plotter, Raster, save_figure
+from asp_plot.utils import Plotter, Raster
 
 logging.basicConfig(level=logging.WARNING)
 logger = logging.getLogger(__name__)
@@ -238,34 +237,6 @@ class GalleryPlotter(Plotter):
             return max(1, int(np.ceil(longest / GALLERY_TARGET_PX)))
         return self.downsample
 
-    def _hillshade_at(self, fn, shape):
-        """
-        Compute a GDAL hillshade for ``fn`` matching a downsampled DEM shape.
-
-        Mirrors ``Raster.hillshade()`` (GDAL ``hillshade``, computeEdges) but
-        runs on a downsampled in-memory copy so the underlay array matches the
-        downsampled DEM array in shape.
-
-        Parameters
-        ----------
-        fn : str
-            Path to the DEM.
-        shape : tuple of int
-            Target (height, width) of the downsampled DEM.
-
-        Returns
-        -------
-        numpy.ma.MaskedArray
-            Hillshade array (nodata masked at 0).
-        """
-        out_h, out_w = shape
-        gdal_ds = gdal.Open(fn)
-        mem = gdal.Translate("", gdal_ds, format="MEM", width=out_w, height=out_h)
-        hs_ds = gdal.DEMProcessing(
-            "", mem, "hillshade", format="MEM", computeEdges=True
-        )
-        return np.ma.masked_equal(hs_ds.ReadAsArray(), 0)
-
     def plot_gallery(
         self,
         hillshade=True,
@@ -388,7 +359,7 @@ class GalleryPlotter(Plotter):
                 [x_in / fig_w, y_in / fig_h, panel_w / fig_w, panel_h / fig_h]
             )
             if hillshade:
-                hs = self._hillshade_at(fn, array.shape)
+                hs = Raster(fn).hillshade(shape=array.shape)
                 self.plot_array(ax=ax, array=hs, cmap="gray", add_cbar=False)
                 im = self.plot_array(
                     ax=ax,
@@ -420,7 +391,6 @@ class GalleryPlotter(Plotter):
             )
             cbar.set_label(cbar_label)
 
-        if save_dir and fig_fn:
-            save_figure(fig, save_dir, fig_fn, dpi=dpi)
+        self.save(fig, save_dir, fig_fn, tight_layout=False, dpi=dpi)
 
         return fig

--- a/asp_plot/scenes.py
+++ b/asp_plot/scenes.py
@@ -3,17 +3,55 @@ import os
 
 import matplotlib.pyplot as plt
 
-from asp_plot.utils import (
-    Plotter,
-    Raster,
-    add_copyright_overlay,
-    detect_vantor_satellite,
-    glob_file,
-    save_figure,
-)
+from asp_plot.utils import Plotter, Raster, detect_vantor_satellite, glob_file
 
 logging.basicConfig(level=logging.WARNING)
 logger = logging.getLogger(__name__)
+
+
+class SceneFiles:
+    """
+    Discover the left/right sub-sampled scene files for a stereo directory.
+
+    Isolates file discovery from the plotting in ``ScenePlotter``, mirroring the
+    ``StereoFiles`` / ``StereoPlotter`` split. Resolved paths and flags are
+    exposed as plain attributes for ``ScenePlotter`` to consume.
+
+    Attributes
+    ----------
+    directory : str
+        Root directory of ASP processing.
+    stereo_directory : str
+        Subdirectory containing stereo outputs.
+    full_stereo_directory : str
+        Full path to the stereo directory.
+    is_vantor : bool
+        Whether the source imagery is from a Vantor (WorldView) satellite.
+    left_scene_sub_fn, right_scene_sub_fn : str or None
+        Paths to the left/right sub-sampled scene files.
+    """
+
+    def __init__(self, directory, stereo_directory):
+        """
+        Discover the sub-sampled scene files.
+
+        Parameters
+        ----------
+        directory : str
+            Root directory of ASP processing.
+        stereo_directory : str
+            Subdirectory containing stereo outputs. The left and right
+            sub-sampled images are located here (``*-L_sub.tif`` /
+            ``*-R_sub.tif``).
+        """
+        self.directory = os.path.expanduser(directory)
+        self.stereo_directory = stereo_directory
+        self.full_stereo_directory = os.path.join(self.directory, stereo_directory)
+
+        self.is_vantor = detect_vantor_satellite(self.directory)
+
+        self.left_scene_sub_fn = glob_file(self.full_stereo_directory, "*-L_sub.tif")
+        self.right_scene_sub_fn = glob_file(self.full_stereo_directory, "*-R_sub.tif")
 
 
 class ScenePlotter(Plotter):
@@ -64,17 +102,32 @@ class ScenePlotter(Plotter):
         This constructor attempts to locate the left and right
         subsampled image files in the stereo directory. These files are
         generated during ASP stereo processing with names ending in
-        "-L_sub.tif" and "-R_sub.tif" respectively.
+        "-L_sub.tif" and "-R_sub.tif" respectively. File discovery is delegated
+        to :class:`SceneFiles`; the resolved paths are exposed as read-only
+        properties on this plotter.
         """
-        super().__init__(**kwargs)
-        self.directory = os.path.expanduser(directory)
-        self.stereo_directory = stereo_directory
-        self.full_stereo_directory = os.path.join(self.directory, stereo_directory)
+        self.files = SceneFiles(directory, stereo_directory)
+        super().__init__(is_vantor=self.files.is_vantor, **kwargs)
 
-        self.is_vantor = detect_vantor_satellite(self.directory)
+    @property
+    def directory(self):
+        return self.files.directory
 
-        self.left_scene_sub_fn = glob_file(self.full_stereo_directory, "*-L_sub.tif")
-        self.right_scene_sub_fn = glob_file(self.full_stereo_directory, "*-R_sub.tif")
+    @property
+    def stereo_directory(self):
+        return self.files.stereo_directory
+
+    @property
+    def full_stereo_directory(self):
+        return self.files.full_stereo_directory
+
+    @property
+    def left_scene_sub_fn(self):
+        return self.files.left_scene_sub_fn
+
+    @property
+    def right_scene_sub_fn(self):
+        return self.files.right_scene_sub_fn
 
     def plot_scenes(self, save_dir=None, fig_fn=None):
         """
@@ -117,17 +170,23 @@ class ScenePlotter(Plotter):
         axa = axa.ravel()
 
         left_scene_ma = left_scene.read_array()
-        self.plot_array(ax=axa[0], array=left_scene_ma, cmap="gray", add_cbar=False)
+        self.plot_array(
+            ax=axa[0],
+            array=left_scene_ma,
+            cmap="gray",
+            add_cbar=False,
+            copyright=True,
+        )
         axa[0].set_title(f"Left\n{os.path.basename(self.left_scene_sub_fn)}", size=8)
-        if self.is_vantor:
-            add_copyright_overlay(axa[0])
 
         right_scene_ma = Raster(self.right_scene_sub_fn).read_array()
-        self.plot_array(ax=axa[1], array=right_scene_ma, cmap="gray", add_cbar=False)
+        self.plot_array(
+            ax=axa[1],
+            array=right_scene_ma,
+            cmap="gray",
+            add_cbar=False,
+            copyright=True,
+        )
         axa[1].set_title(f"Right\n{os.path.basename(self.right_scene_sub_fn)}", size=8)
-        if self.is_vantor:
-            add_copyright_overlay(axa[1])
 
-        fig.tight_layout()
-        if save_dir and fig_fn:
-            save_figure(fig, save_dir, fig_fn)
+        self.save(fig, save_dir, fig_fn)

--- a/asp_plot/stereo.py
+++ b/asp_plot/stereo.py
@@ -14,18 +14,152 @@ from asp_plot.selections import (
     pixel_window_to_bbox,
     reproject_bbox,
 )
-from asp_plot.utils import (
-    ColorBar,
-    Plotter,
-    Raster,
-    add_copyright_overlay,
-    detect_vantor_satellite,
-    glob_file,
-    save_figure,
-)
+from asp_plot.utils import ColorBar, Plotter, Raster, detect_vantor_satellite, glob_file
 
 logging.basicConfig(level=logging.WARNING)
 logger = logging.getLogger(__name__)
+
+
+class StereoFiles:
+    """
+    Discover the ASP stereo output files for a processing directory.
+
+    This isolates file discovery (globbing for DEMs, disparity maps, match
+    files, reference DEM, etc.) from the plotting in ``StereoPlotter``,
+    mirroring the ``ReadBundleAdjustFiles`` / ``PlotBundleAdjustFiles`` split.
+    The resolved paths and flags are exposed as plain attributes, which
+    ``StereoPlotter`` consumes.
+
+    Attributes
+    ----------
+    directory : str
+        Root directory for ASP processing.
+    stereo_directory : str
+        Directory containing stereo processing outputs.
+    full_directory : str
+        Full path to the stereo directory.
+    is_vantor : bool
+        Whether the source imagery is from a Vantor (WorldView) satellite.
+    reference_dem : str or None
+        Path to the reference DEM (supplied or recovered from the stereo log).
+    left_image_fn, left_image_sub_fn, right_image_sub_fn : str or None
+        Left/right (sub-sampled) image paths.
+    orthos : bool
+        Whether the left image is map-projected.
+    align_left_fn, align_right_fn : str or None
+        Alignment transform text files.
+    match_point_fn : str
+        Match-point file (the non-``-disp-`` one when several exist).
+    disparity_sub_fn, disparity_fn : str or None
+        Sub-sampled and full disparity map paths.
+    dem_gsd : float or None
+        Ground sample distance of the DEM in meters.
+    dem_fn : str
+        Path to the stereo DEM.
+    intersection_error_fn : str or None
+        Triangulation intersection-error raster.
+    """
+
+    def __init__(
+        self,
+        directory,
+        stereo_directory,
+        dem_gsd=None,
+        dem_fn=None,
+        reference_dem=None,
+    ):
+        """
+        Discover stereo output files.
+
+        Parameters
+        ----------
+        directory : str
+            Root directory for ASP processing.
+        stereo_directory : str
+            Directory containing stereo processing outputs.
+        dem_gsd : float, optional
+            Ground sample distance of the DEM in meters.
+        dem_fn : str, optional
+            Path to the DEM file, default is None (automatically detected).
+        reference_dem : str, optional
+            Path to the reference DEM file, default is None (recovered from the
+            stereo log).
+
+        Raises
+        ------
+        ValueError
+            If no DEM file is found in the stereo directory.
+        """
+        self.directory = os.path.expanduser(directory)
+        self.stereo_directory = stereo_directory
+        self.is_vantor = detect_vantor_satellite(self.directory)
+
+        if reference_dem:
+            self.reference_dem = os.path.expanduser(reference_dem)
+        else:
+            processing_parameters = ProcessingParameters(
+                processing_directory=self.directory,
+                stereo_directory=self.stereo_directory,
+            )
+            self.reference_dem = processing_parameters.from_stereo_log(
+                search_for_reference_dem=True
+            )[-1]
+            if not self.reference_dem:
+                logger.warning(
+                    "\n\nNo reference DEM found in log files. Please supply the reference DEM you used during stereo processing (or another reference DEM) if you would like to see some difference maps.\n\n"
+                )
+            # If the reference DEM path from the log is relative, make it absolute
+            elif not os.path.isabs(self.reference_dem):
+                self.reference_dem = os.path.join(self.directory, self.reference_dem)
+        if self.reference_dem:
+            print(f"\nReference DEM: {self.reference_dem}\n")
+
+        self.full_directory = os.path.join(self.directory, self.stereo_directory)
+        self.left_image_fn = glob_file(self.full_directory, "*-L.tif")
+        # Set processing flag if the left image is not mapprojected
+        self.orthos = False if Raster(self.left_image_fn).transform is None else True
+        self.left_image_sub_fn = glob_file(self.full_directory, "*-L_sub.tif")
+        self.right_image_sub_fn = glob_file(self.full_directory, "*-R_sub.tif")
+        self.align_left_fn = glob_file(self.full_directory, "*-align-L.txt")
+        self.align_right_fn = glob_file(self.full_directory, "*-align-R.txt")
+
+        # There may be multiple match files if stereo was run with --num-matches-from-disparity.
+        # In that case, filter out the match file with `-disp-` in filename.
+        match_files = glob_file(self.full_directory, "*.match", all_files=True)
+        self.match_point_fn = [f for f in match_files if "-disp-" not in f][0]
+
+        self.disparity_sub_fn = glob_file(self.full_directory, "*-D_sub.tif")
+        # We only need the full disparity file to retrieve the GSD for plotting
+        # and rescaling below.
+        self.disparity_fn = glob_file(self.full_directory, "*-D.tif")
+
+        self.dem_gsd = dem_gsd
+
+        if not dem_fn:
+            if self.dem_gsd is not None:
+                self.dem_fn = glob_file(
+                    self.full_directory,
+                    f"*-DEM_{self.dem_gsd}m.tif",
+                    f"*{self.dem_gsd}m-DEM.tif",
+                )
+            else:
+                self.dem_fn = glob_file(
+                    self.full_directory,
+                    "*-DEM.tif",
+                )
+        else:
+            self.dem_fn = glob_file(self.full_directory, dem_fn)
+
+        if not self.dem_fn:
+            raise ValueError(
+                f"\n\nDEM file not found in {self.full_directory}. Make sure it is there and possibly specify the GSD with the dem_gsd argument.\n\n"
+            )
+        else:
+            print(f"\nASP DEM: {self.dem_fn}\n")
+
+        self.intersection_error_fn = glob_file(
+            self.full_directory, "*-IntersectionErr.tif"
+        )
 
 
 class StereoPlotter(Plotter):
@@ -98,79 +232,84 @@ class StereoPlotter(Plotter):
         Notes
         -----
         If dem_fn is not provided, the class will try to find a DEM in the
-        stereo directory with a pattern like *-DEM.tif or *_dem.tif.
+        stereo directory with a pattern like *-DEM.tif or *_dem.tif. File
+        discovery is delegated to :class:`StereoFiles`; the resolved paths are
+        exposed as read-only properties on this plotter.
         """
-        super().__init__(**kwargs)
-        self.directory = os.path.expanduser(directory)
-        self.stereo_directory = stereo_directory
-        self.is_vantor = detect_vantor_satellite(self.directory)
-
-        if reference_dem:
-            self.reference_dem = os.path.expanduser(reference_dem)
-        else:
-            processing_parameters = ProcessingParameters(
-                processing_directory=self.directory,
-                stereo_directory=self.stereo_directory,
-            )
-            self.reference_dem = processing_parameters.from_stereo_log(
-                search_for_reference_dem=True
-            )[-1]
-            if not self.reference_dem:
-                logger.warning(
-                    "\n\nNo reference DEM found in log files. Please supply the reference DEM you used during stereo processing (or another reference DEM) if you would like to see some difference maps.\n\n"
-                )
-            # If the reference DEM path from the log is relative, make it absolute
-            elif not os.path.isabs(self.reference_dem):
-                self.reference_dem = os.path.join(self.directory, self.reference_dem)
-        if self.reference_dem:
-            print(f"\nReference DEM: {self.reference_dem}\n")
-
-        self.full_directory = os.path.join(self.directory, self.stereo_directory)
-        self.left_image_fn = glob_file(self.full_directory, "*-L.tif")
-        # Set processing flag if the left image is not mapprojected
-        self.orthos = False if Raster(self.left_image_fn).transform is None else True
-        self.left_image_sub_fn = glob_file(self.full_directory, "*-L_sub.tif")
-        self.right_image_sub_fn = glob_file(self.full_directory, "*-R_sub.tif")
-        self.align_left_fn = glob_file(self.full_directory, "*-align-L.txt")
-        self.align_right_fn = glob_file(self.full_directory, "*-align-R.txt")
-
-        # There may be multiple match files if stereo was run with --num-matches-from-disparity.
-        # In that case, filter out the match file with `-disp-` in filename.
-        match_files = glob_file(self.full_directory, "*.match", all_files=True)
-        self.match_point_fn = [f for f in match_files if "-disp-" not in f][0]
-
-        self.disparity_sub_fn = glob_file(self.full_directory, "*-D_sub.tif")
-        # We only need the full disparity file to retrieve the GSD for plotting
-        # and rescaling below.
-        self.disparity_fn = glob_file(self.full_directory, "*-D.tif")
-
-        self.dem_gsd = dem_gsd
-
-        if not dem_fn:
-            if self.dem_gsd is not None:
-                self.dem_fn = glob_file(
-                    self.full_directory,
-                    f"*-DEM_{self.dem_gsd}m.tif",
-                    f"*{self.dem_gsd}m-DEM.tif",
-                )
-            else:
-                self.dem_fn = glob_file(
-                    self.full_directory,
-                    "*-DEM.tif",
-                )
-        else:
-            self.dem_fn = glob_file(self.full_directory, dem_fn)
-
-        if not self.dem_fn:
-            raise ValueError(
-                f"\n\nDEM file not found in {self.full_directory}. Make sure it is there and possibly specify the GSD with the dem_gsd argument.\n\n"
-            )
-        else:
-            print(f"\nASP DEM: {self.dem_fn}\n")
-
-        self.intersection_error_fn = glob_file(
-            self.full_directory, "*-IntersectionErr.tif"
+        self.files = StereoFiles(
+            directory,
+            stereo_directory,
+            dem_gsd=dem_gsd,
+            dem_fn=dem_fn,
+            reference_dem=reference_dem,
         )
+        super().__init__(is_vantor=self.files.is_vantor, **kwargs)
+
+    # File discovery lives in StereoFiles; expose the resolved paths/flags as
+    # read-only properties so the plotting methods can keep using ``self.<attr>``.
+    @property
+    def directory(self):
+        return self.files.directory
+
+    @property
+    def stereo_directory(self):
+        return self.files.stereo_directory
+
+    @property
+    def full_directory(self):
+        return self.files.full_directory
+
+    @property
+    def reference_dem(self):
+        return self.files.reference_dem
+
+    @property
+    def left_image_fn(self):
+        return self.files.left_image_fn
+
+    @property
+    def orthos(self):
+        return self.files.orthos
+
+    @property
+    def left_image_sub_fn(self):
+        return self.files.left_image_sub_fn
+
+    @property
+    def right_image_sub_fn(self):
+        return self.files.right_image_sub_fn
+
+    @property
+    def align_left_fn(self):
+        return self.files.align_left_fn
+
+    @property
+    def align_right_fn(self):
+        return self.files.align_right_fn
+
+    @property
+    def match_point_fn(self):
+        return self.files.match_point_fn
+
+    @property
+    def disparity_sub_fn(self):
+        return self.files.disparity_sub_fn
+
+    @property
+    def disparity_fn(self):
+        return self.files.disparity_fn
+
+    @property
+    def dem_gsd(self):
+        return self.files.dem_gsd
+
+    @property
+    def dem_fn(self):
+        return self.files.dem_fn
+
+    @property
+    def intersection_error_fn(self):
+        return self.files.intersection_error_fn
 
     def read_ip_record(self, match_file):
         """
@@ -344,8 +483,20 @@ class StereoPlotter(Plotter):
 
             left_image = Raster(self.left_image_sub_fn).read_array()
             right_image = Raster(self.right_image_sub_fn).read_array()
-            self.plot_array(ax=axa[0], array=left_image, cmap="gray", add_cbar=False)
-            self.plot_array(ax=axa[1], array=right_image, cmap="gray", add_cbar=False)
+            self.plot_array(
+                ax=axa[0],
+                array=left_image,
+                cmap="gray",
+                add_cbar=False,
+                copyright=True,
+            )
+            self.plot_array(
+                ax=axa[1],
+                array=right_image,
+                cmap="gray",
+                add_cbar=False,
+                copyright=True,
+            )
             axa[0].set_title(f"Left (n={match_point_df.shape[0]})")
             axa[1].set_title("Right")
 
@@ -368,32 +519,12 @@ class StereoPlotter(Plotter):
                 s=1,
             )
             axa[1].set_aspect("equal")
-
-            if self.is_vantor:
-                add_copyright_overlay(axa[0])
-                add_copyright_overlay(axa[1])
         else:
-            axa[0].text(
-                0.5,
-                0.5,
-                "One or more required\nfiles are missing",
-                horizontalalignment="center",
-                verticalalignment="center",
-                transform=axa[0].transAxes,
-            )
-            axa[1].text(
-                0.5,
-                0.5,
-                "One or more required\nfiles are missing",
-                horizontalalignment="center",
-                verticalalignment="center",
-                transform=axa[1].transAxes,
-            )
+            self.plot_missing(axa[0])
+            self.plot_missing(axa[1])
 
         fig.suptitle(self.title, size=10)
-        fig.tight_layout()
-        if save_dir and fig_fn:
-            save_figure(fig, save_dir, fig_fn)
+        self.save(fig, save_dir, fig_fn)
 
     def plot_disparity(
         self, unit="pixels", remove_bias=True, quiver=True, save_dir=None, fig_fn=None
@@ -512,18 +643,9 @@ class StereoPlotter(Plotter):
             axa[2].set_title("offset magnitude")
         else:
             for ax in axa:
-                ax.text(
-                    0.5,
-                    0.5,
-                    "One or more required\nfiles are missing",
-                    horizontalalignment="center",
-                    verticalalignment="center",
-                    transform=ax.transAxes,
-                )
+                self.plot_missing(ax)
 
-        fig.tight_layout()
-        if save_dir and fig_fn:
-            save_figure(fig, save_dir, fig_fn)
+        self.save(fig, save_dir, fig_fn)
 
     def _auto_hillshade_clip_offsets(
         self, ie, subset_size, intersection_error_percentiles
@@ -668,9 +790,7 @@ class StereoPlotter(Plotter):
             hs = raster.hillshade()
             self._plot_hillshade_with_overlay(ax, dem, hs, gsd)
 
-            fig.tight_layout()
-            if save_dir and fig_fn:
-                save_figure(fig, save_dir, fig_fn)
+            self.save(fig, save_dir, fig_fn)
 
             return
 
@@ -823,9 +943,8 @@ class StereoPlotter(Plotter):
                     clim=clim,
                     cmap="gray",
                     add_cbar=False,
+                    copyright=True,
                 )
-                if self.is_vantor:
-                    add_copyright_overlay(ax_img)
                 axes_to_modify = [ax_hs, ax_img]
             else:
                 plt.delaxes(ax_img)
@@ -839,8 +958,7 @@ class StereoPlotter(Plotter):
                     spine.set_color(color)
                     spine.set_linewidth(4)
 
-        if save_dir and fig_fn:
-            save_figure(fig, save_dir, fig_fn)
+        self.save(fig, save_dir, fig_fn, tight_layout=False)
 
     def get_diff_vs_reference(self):
         """
@@ -969,14 +1087,7 @@ class StereoPlotter(Plotter):
             hs = raster.hillshade()
             self._plot_hillshade_with_overlay(axa[0], dem, hs, gsd, clim=el_clim)
         else:
-            axa[0].text(
-                0.5,
-                0.5,
-                "One or more required\nfiles are missing",
-                horizontalalignment="center",
-                verticalalignment="center",
-                transform=axa[0].transAxes,
-            )
+            self.plot_missing(axa[0])
         axa[0].set_title("Stereo DEM")
 
         if self.intersection_error_fn:
@@ -989,14 +1100,7 @@ class StereoPlotter(Plotter):
                 cbar_label="Distance (m)",
             )
         else:
-            axa[1].text(
-                0.5,
-                0.5,
-                "One or more required\nfiles are missing",
-                horizontalalignment="center",
-                verticalalignment="center",
-                transform=axa[1].transAxes,
-            )
+            self.plot_missing(axa[1])
         axa[1].set_title("Triangulation intersection error")
 
         diff = self.get_diff_vs_reference()
@@ -1012,16 +1116,7 @@ class StereoPlotter(Plotter):
                 cbar_label="Elevation diff. (m)",
             )
         else:
-            axa[2].text(
-                0.5,
-                0.5,
-                "One or more required\nfiles are missing",
-                horizontalalignment="center",
-                verticalalignment="center",
-                transform=axa[2].transAxes,
-            )
+            self.plot_missing(axa[2])
         axa[2].set_title("Reference DEM $-$ Stereo DEM")
 
-        fig.tight_layout()
-        if save_dir and fig_fn:
-            save_figure(fig, save_dir, fig_fn)
+        self.save(fig, save_dir, fig_fn)

--- a/asp_plot/utils.py
+++ b/asp_plot/utils.py
@@ -527,7 +527,7 @@ class ColorBar:
             extend = "min"
         return extend
 
-    def get_norm(self, lognorm=False):
+    def get_norm(self, lognorm=False, clim=None):
         """
         Get normalization for colormap.
 
@@ -535,17 +535,18 @@ class ColorBar:
         ----------
         lognorm : bool, optional
             Whether to use logarithmic normalization, default is False
+        clim : tuple, optional
+            Explicit color limits (min, max) to normalize against. If None
+            (default), falls back to ``self.clim`` (set by a prior ``get_clim``
+            or ``find_common_clim`` call). Passing ``clim`` explicitly avoids
+            relying on the mutable ``self.clim`` state.
 
         Returns
         -------
         matplotlib.colors.Normalize
             Normalization object for matplotlib colormaps
-
-        Notes
-        -----
-        Requires the clim attribute to be set (by calling get_clim or find_common_clim)
         """
-        vmin, vmax = self.clim
+        vmin, vmax = clim if clim is not None else self.clim
         if lognorm:
             norm = matplotlib.colors.LogNorm(vmin=vmin, vmax=vmax)
         else:
@@ -851,30 +852,45 @@ class Raster:
         else:
             return bounds
 
-    def hillshade(self):
+    def hillshade(self, shape=None):
         """
         Generate a hillshade from the raster.
+
+        Parameters
+        ----------
+        shape : tuple of int or None, optional
+            Target ``(height, width)`` for the hillshade. When given, the source
+            is resampled to this shape (in memory) before computing the
+            hillshade, so the result matches a downsampled DEM array. When None
+            (default), the hillshade is computed at full resolution and a
+            cached ``*_hs.tif`` file is reused if present.
 
         Returns
         -------
         numpy.ma.MaskedArray
-            Hillshade array
+            Hillshade array (nodata masked at 0).
 
         Notes
         -----
-        First checks if a hillshade file already exists with "_hs.tif" suffix.
-        If not, generates the hillshade using GDAL.
+        At full resolution this first checks for a sibling ``*_hs.tif`` file and
+        reuses it; otherwise it generates the hillshade using GDAL
+        (``computeEdges``). The cache is skipped when ``shape`` is given, since
+        the cached file is full-resolution.
         """
-        hs_fn = os.path.splitext(self.fn)[0] + "_hs.tif"
-        if os.path.exists(hs_fn):
-            hillshade = Raster(hs_fn).read_array()
+        if shape is None:
+            hs_fn = os.path.splitext(self.fn)[0] + "_hs.tif"
+            if os.path.exists(hs_fn):
+                return Raster(hs_fn).read_array()
+            src = gdal.Open(self.fn)
         else:
-            gdal_ds = gdal.Open(self.fn)
-            hs_ds = gdal.DEMProcessing(
-                "", gdal_ds, "hillshade", format="MEM", computeEdges=True
+            out_h, out_w = shape
+            src = gdal.Translate(
+                "", gdal.Open(self.fn), format="MEM", width=out_w, height=out_h
             )
-            hillshade = np.ma.masked_equal(hs_ds.ReadAsArray(), 0)
-        return hillshade
+        hs_ds = gdal.DEMProcessing(
+            "", src, "hillshade", format="MEM", computeEdges=True
+        )
+        return np.ma.masked_equal(hs_ds.ReadAsArray(), 0)
 
     def compute_difference(self, second_fn, save=False):
         """
@@ -1062,6 +1078,7 @@ class Plotter:
         clim_perc=(2, 98),
         lognorm=False,
         title=None,
+        is_vantor=False,
     ):
         """
         Initialize the Plotter.
@@ -1074,11 +1091,67 @@ class Plotter:
             Whether to use logarithmic color normalization, default is False
         title : str, optional
             Plot title, default is None
+        is_vantor : bool, optional
+            Whether the source imagery is from a Vantor (WorldView) satellite.
+            When True, ``plot_array`` adds a copyright overlay for panels that
+            request it via ``copyright=True``. Default is False.
         """
         self.clim_perc = clim_perc
         self.lognorm = lognorm
         self.title = title
+        self.is_vantor = is_vantor
         self.cb = ColorBar(perc_range=self.clim_perc)
+
+    def save(self, fig, save_dir=None, fig_fn=None, tight_layout=True, **kwargs):
+        """
+        Finalize and optionally save a figure.
+
+        Centralizes the save tail duplicated across plotting methods: an
+        optional ``fig.tight_layout()`` followed by a write to disk only when
+        both ``save_dir`` and ``fig_fn`` are given.
+
+        Parameters
+        ----------
+        fig : matplotlib.figure.Figure
+            Figure to finalize.
+        save_dir : str or None, optional
+            Directory to save the figure, default is None (don't save).
+        fig_fn : str or None, optional
+            Filename for the saved figure, default is None (don't save).
+        tight_layout : bool, optional
+            Whether to call ``fig.tight_layout()`` first, default is True.
+            Pass False for figures using absolute (``add_axes``) layouts.
+        **kwargs
+            Additional keyword arguments forwarded to ``save_figure`` (e.g.
+            ``dpi``).
+        """
+        if tight_layout:
+            fig.tight_layout()
+        if save_dir and fig_fn:
+            save_figure(fig, save_dir, fig_fn, **kwargs)
+
+    @staticmethod
+    def plot_missing(ax, message="One or more required\nfiles are missing"):
+        """
+        Draw a centered "missing files" placeholder on an empty axes.
+
+        Replaces the placeholder text block duplicated across plotting methods.
+
+        Parameters
+        ----------
+        ax : matplotlib.axes.Axes
+            Axes to annotate.
+        message : str, optional
+            Placeholder text, default "One or more required\\nfiles are missing".
+        """
+        ax.text(
+            0.5,
+            0.5,
+            message,
+            horizontalalignment="center",
+            verticalalignment="center",
+            transform=ax.transAxes,
+        )
 
     def plot_array(
         self,
@@ -1089,6 +1162,7 @@ class Plotter:
         add_cbar=True,
         cbar_label=None,
         alpha=1,
+        copyright=False,
     ):
         """
         Plot a 2D array on the given axes.
@@ -1109,6 +1183,12 @@ class Plotter:
             Label for the colorbar, default is None
         alpha : float, optional
             Transparency (0-1), default is 1
+        copyright : bool, optional
+            Whether to add a satellite-imagery copyright overlay, default is
+            False. The overlay is only drawn when this is True *and* the Plotter
+            was created with ``is_vantor=True`` (i.e. the source imagery is from
+            a Vantor/WorldView satellite). Set on the panels that display the
+            optical scenes.
 
         Returns
         -------
@@ -1145,6 +1225,9 @@ class Plotter:
         ax.set_xticks([])
         ax.set_yticks([])
         ax.set_title(self.title)
+
+        if copyright and self.is_vantor:
+            add_copyright_overlay(ax)
 
         return im
 
@@ -1188,10 +1271,8 @@ class Plotter:
         If ctx_kwargs are provided, adds a basemap using contextily.
         """
         if clim is None:
-            self.cb.get_clim(gdf[column_name])
-        else:
-            self.cb.clim = clim
-        norm = self.cb.get_norm(self.lognorm)
+            clim = self.cb.get_clim(gdf[column_name])
+        norm = self.cb.get_norm(self.lognorm, clim=clim)
 
         gdf.plot(
             ax=ax,

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -51,7 +51,7 @@ class TestImports:
         from asp_plot.gallery import GalleryPlotter
         from asp_plot.processing_parameters import ProcessingParameters
         from asp_plot.report_pipeline import ReportConfig, run_report
-        from asp_plot.scenes import ScenePlotter
+        from asp_plot.scenes import SceneFiles, ScenePlotter
         from asp_plot.selections import FigureSelections
         from asp_plot.sensors import (
             SENSORS,
@@ -59,7 +59,7 @@ class TestImports:
             WorldViewMetadata,
             sensor_for_directory,
         )
-        from asp_plot.stereo import StereoPlotter
+        from asp_plot.stereo import StereoFiles, StereoPlotter
         from asp_plot.stereo_geometry import StereoGeometryPlotter
         from asp_plot.stereopair_metadata_parser import StereopairMetadataParser
         from asp_plot.utils import ColorBar, Plotter, Raster
@@ -72,6 +72,8 @@ class TestImports:
         assert Plotter is not None
         assert StereopairMetadataParser is not None
         assert ScenePlotter is not None
+        assert SceneFiles is not None
+        assert StereoFiles is not None
         assert ProcessingParameters is not None
         assert ReadBundleAdjustFiles is not None
         assert PlotBundleAdjustFiles is not None

--- a/tests/test_scenes.py
+++ b/tests/test_scenes.py
@@ -1,9 +1,24 @@
 import matplotlib
 import pytest
 
-from asp_plot.scenes import ScenePlotter
+from asp_plot.scenes import SceneFiles, ScenePlotter
 
 matplotlib.use("Agg")
+
+
+class TestSceneFiles:
+    """File discovery is isolated in SceneFiles, separate from plotting."""
+
+    @pytest.fixture
+    def files(self):
+        return SceneFiles(directory="tests/test_data", stereo_directory="stereo")
+
+    def test_discovers_sub_scenes(self, files):
+        assert files.left_scene_sub_fn is not None
+        assert files.right_scene_sub_fn is not None
+
+    def test_is_vantor_flag(self, files):
+        assert files.is_vantor is True
 
 
 class TestScenePlotter:
@@ -18,6 +33,11 @@ class TestScenePlotter:
     def test_is_vantor_detection(self, scene_plotter):
         """Test that ScenePlotter detects Vantor satellite from test data XMLs."""
         assert scene_plotter.is_vantor is True
+
+    def test_composes_scene_files(self, scene_plotter):
+        """ScenePlotter delegates discovery to a SceneFiles instance."""
+        assert isinstance(scene_plotter.files, SceneFiles)
+        assert scene_plotter.left_scene_sub_fn == scene_plotter.files.left_scene_sub_fn
 
     def test_plot_scenes(self, scene_plotter):
         try:

--- a/tests/test_stereo.py
+++ b/tests/test_stereo.py
@@ -1,9 +1,56 @@
 import matplotlib
 import pytest
 
-from asp_plot.stereo import StereoPlotter
+from asp_plot.stereo import StereoFiles, StereoPlotter
 
 matplotlib.use("Agg")
+
+
+class TestStereoFiles:
+    """File discovery is isolated in StereoFiles, separate from plotting."""
+
+    @pytest.fixture
+    def files(self):
+        return StereoFiles(
+            directory="tests/test_data",
+            stereo_directory="stereo",
+            dem_gsd=1,
+            reference_dem="tests/test_data/ref_dem.tif",
+        )
+
+    def test_discovers_dem(self, files):
+        assert files.dem_fn is not None
+        assert files.dem_fn.endswith("-DEM.tif")
+
+    def test_discovers_match_and_disparity(self, files):
+        assert files.match_point_fn is not None
+        assert "-disp-" not in files.match_point_fn
+
+    def test_is_vantor_flag(self, files):
+        assert files.is_vantor is True
+
+
+class TestStereoPlotterComposition:
+    """StereoPlotter delegates discovery to a StereoFiles instance."""
+
+    @pytest.fixture
+    def stereo_plotter(self):
+        return StereoPlotter(
+            directory="tests/test_data",
+            stereo_directory="stereo",
+            dem_gsd=1,
+            reference_dem="tests/test_data/ref_dem.tif",
+        )
+
+    def test_has_files_index(self, stereo_plotter):
+        assert isinstance(stereo_plotter.files, StereoFiles)
+
+    def test_properties_delegate_to_files(self, stereo_plotter):
+        assert stereo_plotter.dem_fn == stereo_plotter.files.dem_fn
+        assert stereo_plotter.full_directory == stereo_plotter.files.full_directory
+
+    def test_is_vantor_passed_to_plotter(self, stereo_plotter):
+        assert stereo_plotter.is_vantor == stereo_plotter.files.is_vantor
 
 
 class TestStereoPlotter:
@@ -51,7 +98,7 @@ class TestStereoPlotter:
 
     @pytest.fixture
     def stereo_plotter_without_intersection_error(self, stereo_plotter):
-        stereo_plotter.intersection_error_fn = None
+        stereo_plotter.files.intersection_error_fn = None
         return stereo_plotter
 
     def test_is_vantor_detection(self, stereo_plotter):
@@ -113,7 +160,7 @@ class TestStereoPlotterNoMapproj:
     def stereo_plotter_no_mapproj_no_intersection_error(
         self, stereo_plotter_no_mapproj
     ):
-        stereo_plotter_no_mapproj.intersection_error_fn = None
+        stereo_plotter_no_mapproj.files.intersection_error_fn = None
         return stereo_plotter_no_mapproj
 
     def test_is_not_vantor(self, stereo_plotter_no_mapproj):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,6 +9,7 @@ from PIL import Image
 from asp_plot.report import ReportMetadata, ReportSection, compile_report
 from asp_plot.utils import (
     ColorBar,
+    Plotter,
     Raster,
     add_copyright_overlay,
     detect_planetary_body,
@@ -177,6 +178,15 @@ class TestRaster:
         assert isinstance(hillshade, np.ma.MaskedArray)
         assert hillshade.ndim == 2
 
+    def test_hillshade_with_shape(self, test_dem):
+        """Hillshade resampled to a target shape (used by the gallery)."""
+        raster = Raster(test_dem)
+        full = raster.hillshade()
+        shape = (full.shape[0] // 2, full.shape[1] // 2)
+        hs = raster.hillshade(shape=shape)
+        assert isinstance(hs, np.ma.MaskedArray)
+        assert hs.shape == shape
+
     def test_load_and_diff_rasters(self, test_dem, test_ref_dem):
         """Test static method for loading and differencing rasters."""
         diff, transform, crs, nodata = Raster.load_and_diff_rasters(
@@ -292,6 +302,66 @@ class TestColorBar:
         cb.get_clim(data)
         norm = cb.get_norm(lognorm=False)
         assert norm is not None
+
+    def test_get_norm_explicit_clim(self):
+        """Explicit clim is used without relying on the mutable self.clim."""
+        cb = ColorBar()
+        norm = cb.get_norm(lognorm=False, clim=(0.0, 10.0))
+        assert norm.vmin == 0.0
+        assert norm.vmax == 10.0
+
+
+class TestPlotter:
+    """Test the Plotter scaffold (save, plot_missing, copyright path)."""
+
+    def test_is_vantor_default_false(self):
+        assert Plotter().is_vantor is False
+
+    def test_plot_array_copyright_overlay(self):
+        """copyright=True draws the overlay only when is_vantor is True."""
+        data = np.ma.masked_invalid(np.random.rand(10, 10))
+
+        plotter = Plotter(is_vantor=True)
+        fig, ax = plt.subplots()
+        plotter.plot_array(ax, data, add_cbar=False, copyright=True)
+        assert any("Vantor" in t.get_text() for t in ax.texts)
+        plt.close(fig)
+
+        plotter = Plotter(is_vantor=False)
+        fig, ax = plt.subplots()
+        plotter.plot_array(ax, data, add_cbar=False, copyright=True)
+        assert not any("Vantor" in t.get_text() for t in ax.texts)
+        plt.close(fig)
+
+    def test_plot_array_no_copyright_by_default(self):
+        """Even an is_vantor plotter adds no overlay unless copyright=True."""
+        data = np.ma.masked_invalid(np.random.rand(10, 10))
+        plotter = Plotter(is_vantor=True)
+        fig, ax = plt.subplots()
+        plotter.plot_array(ax, data, add_cbar=False)
+        assert not any("Vantor" in t.get_text() for t in ax.texts)
+        plt.close(fig)
+
+    def test_plot_missing(self):
+        plotter = Plotter()
+        fig, ax = plt.subplots()
+        plotter.plot_missing(ax)
+        assert any("missing" in t.get_text() for t in ax.texts)
+        plt.close(fig)
+
+    def test_save_writes_file(self, tmp_path):
+        plotter = Plotter()
+        fig, ax = plt.subplots()
+        plotter.save(fig, save_dir=str(tmp_path), fig_fn="out.png")
+        assert (tmp_path / "out.png").exists()
+        plt.close(fig)
+
+    def test_save_no_write_without_filename(self, tmp_path):
+        plotter = Plotter()
+        fig, ax = plt.subplots()
+        plotter.save(fig, save_dir=str(tmp_path), fig_fn=None)
+        assert list(tmp_path.iterdir()) == []
+        plt.close(fig)
 
 
 class TestGetUtmEpsg:


### PR DESCRIPTION
Closes #129. Part of the structural rewrite tracked in #122.

Gives the `Plotter` base class real scaffolding and pulls file discovery out of the plotting classes, removing the duplication called out in the issue. No behavioral/visual changes to the figures.

## Plotter scaffold (`utils.py`)
- **`save(fig, save_dir, fig_fn, tight_layout=True, **kw)`** — centralizes the `fig.tight_layout()` + `if save_dir and fig_fn: save_figure(...)` tail that was copy-pasted at the end of every plot method (stereo ×4, scenes, bundle_adjust, gallery). Gallery passes `tight_layout=False, dpi=...` for its absolute `add_axes` layout.
- **`plot_missing(ax, message=...)`** — the "One or more required files are missing" placeholder block, deduplicated (was repeated ~6×).
- **Copyright into `plot_array`** — `is_vantor` now lives on `Plotter`; `plot_array(..., copyright=True)` draws the Vantor/WorldView overlay on the panels that show optical scenes, so the `if self.is_vantor: add_copyright_overlay(ax)` no longer threads through each call site.
- **Clim ownership fix** — `ColorBar.get_norm` accepts an explicit `clim`, and `plot_geodataframe` keeps `clim` local instead of mutating `self.cb.clim` (matching `plot_array`'s local-clim convention).

## One hillshade implementation (`utils.py`)
- `Raster.hillshade(shape=None)` resamples in-memory to a target shape when given; `GalleryPlotter._hillshade_at` (a near-copy) is removed and the gallery now calls `Raster(fn).hillshade(shape=...)`.

## File discovery separated from plotting
- New **`StereoFiles`** / **`SceneFiles`** discovery classes own all the `glob_file` logic, mirroring the existing `ReadBundleAdjustFiles` / `PlotBundleAdjustFiles` split. `StereoPlotter` / `ScenePlotter` compose a `*Files` instance and expose the resolved paths as read-only `@property` delegates, so the plotting methods are untouched.

## Acceptance criteria
- [x] Shared layout/save/placeholder scaffold; duplicated save tails and placeholder blocks removed
- [x] Copyright + clim path live inside `plot_array` / centralized
- [x] One hillshade implementation in `Raster`
- [x] File discovery separated from `StereoPlotter` / `ScenePlotter`
- [x] Plot tests green; figures visually unchanged

## Tests
- `TestPlotter` (save / plot_missing / copyright gating / `get_norm` explicit clim), `Raster.hillshade(shape=)`, `StereoFiles` / `SceneFiles` discovery + plotter-composition tests, and import checks.
- Full suite: **269 passed**. Lint clean (black/isort/flake8).

## Notes / deferred
- Copyright is intentionally only on the optical-scene panels (not DEM/disparity/gallery panels), so semantics are unchanged.
- The gray-hillshade + α0.5-viridis *overlay drawing* still exists in two spots (stereo `_plot_hillshade_with_overlay` vs gallery inline) because they differ (scalebar/cbar vs shared-colorbar return). The issue's requirement — one hillshade *generation* path in `Raster` — is met. WorldView/Vantor naming reconciliation remains tracked separately in #137.
