### PR TITLE
Make ASP-log parsing a versioned adapter instead of hardcoded string surgery (#132)

### DIFF
--- a/asp_plot/asp_log.py
+++ b/asp_plot/asp_log.py
@@ -1,0 +1,276 @@
+"""
+Versioned adapter for parsing NASA Ames Stereo Pipeline (ASP) log files.
+
+ASP writes one plain-text log per tool invocation (``bundle_adjust``,
+``stereo_pprc`` ... ``stereo_tri``, ``point2dem``). Each log starts with a
+version banner, then the literal command line that was run, then timestamped
+``console`` lines. The exact layout has been stable across ASP 3.x but is not
+guaranteed to stay fixed.
+
+Rather than scatter hardcoded regexes and ``line.split()[0]`` indexing through
+the call sites (which fail silently when the format drifts), all format
+knowledge lives here behind a small adapter that is *keyed by ASP version*. A
+new ASP log layout becomes a new :class:`AspLogFormat` subclass registered in
+``ASP_LOG_FORMATS``; everything downstream keeps working through the stable
+:class:`AspLog` interface.
+
+When a field cannot be parsed the adapter returns ``None`` and logs a warning
+(at ``logger`` level) so format drift surfaces instead of being swallowed.
+"""
+
+import logging
+import os
+import re
+from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+
+# The ordered stages of an ASP stereo run. Used to pick the earliest- and
+# latest-running stereo logs for run-time spans without hardcoding "pprc" and
+# "tri" at the call site -- if either is absent we fall back to the nearest
+# present stage.
+STEREO_STEP_ORDER = (
+    "stereo_pprc",
+    "stereo_corr",
+    "stereo_blend",
+    "stereo_rfne",
+    "stereo_fltr",
+    "stereo_tri",
+)
+
+# Known ASP command-line tools whose invocation may appear as the first token
+# of a log's command line. Used to locate the command line robustly (by the
+# executable basename) instead of by an arbitrary substring match.
+ASP_TOOL_NAMES = frozenset(
+    {
+        "bundle_adjust",
+        "parallel_bundle_adjust",
+        "jitter_solve",
+        "stereo",
+        "parallel_stereo",
+        "point2dem",
+        "pc_align",
+        "dem_mosaic",
+        "mapproject",
+        *STEREO_STEP_ORDER,
+    }
+)
+
+
+class AspLogFormat:
+    """Adapter describing how to read one ASP log layout.
+
+    The base class implements the ASP 3.x layout. To support a drifted format,
+    subclass it, override the class attributes (or methods) that changed, give
+    it a distinguishing :meth:`supports`, and register the subclass in
+    ``ASP_LOG_FORMATS`` ahead of the default.
+    """
+
+    #: Short identifier, surfaced in logs.
+    name = "asp-3.x"
+
+    #: Banner on the first line, e.g. ``ASP 3.4.0-alpha``.
+    version_banner_re = re.compile(r"^ASP\s+(?P<version>\S+)")
+
+    #: A leading ``YYYY-MM-DD HH:MM:SS`` timestamp on a console line.
+    timestamp_re = re.compile(r"^(?P<ts>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})")
+    timestamp_fmt = "%Y-%m-%d %H:%M:%S"
+
+    #: Reference-DEM announcements. ASP phrases this differently per tool
+    #: (``Loading DEM:`` in bundle_adjust, ``Using input DEM:`` in stereo), so
+    #: one case-insensitive pattern covers the known variants.
+    reference_dem_re = re.compile(
+        r"(?:Loading DEM|Using input DEM|Input DEM)\s*:\s*(?P<dem>\S+)",
+        re.IGNORECASE,
+    )
+
+    @classmethod
+    def supports(cls, banner_line):
+        """Whether this adapter handles a log with the given first line.
+
+        The default ASP 3.x adapter claims any ``ASP 3.*`` banner.
+        """
+        match = cls.version_banner_re.match(banner_line or "")
+        if not match:
+            return False
+        return match.group("version").startswith("3.")
+
+    def parse_version(self, banner_line):
+        """Return the ASP version string from the banner, or ``None``."""
+        match = self.version_banner_re.match(banner_line or "")
+        if not match:
+            return None
+        return match.group("version")
+
+    def parse_timestamp(self, line):
+        """Return the :class:`datetime` from a leading timestamp, or ``None``."""
+        match = self.timestamp_re.match(line or "")
+        if not match:
+            return None
+        try:
+            return datetime.strptime(match.group("ts"), self.timestamp_fmt)
+        except ValueError:
+            logger.warning(
+                "%s: could not parse timestamp %r with format %r",
+                self.name,
+                match.group("ts"),
+                self.timestamp_fmt,
+            )
+            return None
+
+    def parse_command_line(self, lines):
+        """Locate the tool invocation line in ``lines``.
+
+        Returns ``(tool, command)`` where ``tool`` is the executable basename
+        (e.g. ``stereo_tri``) and ``command`` is the full stripped command
+        line, or ``None`` if no known ASP tool invocation is found.
+
+        The line is found by matching the basename of its first token against
+        :data:`ASP_TOOL_NAMES`, skipping the banner, build metadata and
+        timestamped console lines -- robust against substring collisions in
+        later log output.
+        """
+        for raw in lines:
+            stripped = raw.strip()
+            if not stripped or self.timestamp_re.match(stripped):
+                continue
+            first_token = stripped.split()[0]
+            tool = os.path.basename(first_token)
+            if tool in ASP_TOOL_NAMES:
+                return tool, stripped
+        return None
+
+    def parse_reference_dem(self, lines):
+        """Return the last reference-DEM path announced in ``lines``, or ``None``.
+
+        The last match wins to mirror the historical behavior (ASP re-announces
+        the DEM and the final mention is the one used).
+        """
+        reference_dem = None
+        for line in lines:
+            match = self.reference_dem_re.search(line)
+            if match:
+                reference_dem = match.group("dem").strip()
+        return reference_dem
+
+
+def register_format(fmt, prepend=True):
+    """Register an :class:`AspLogFormat` subclass for adapter selection.
+
+    The extension point for ASP format drift: when a future ASP version
+    changes the log layout, subclass :class:`AspLogFormat`, override what
+    changed and its :meth:`~AspLogFormat.supports`, then register it here.
+    Registered formats are consulted by :func:`select_format` in order, so by
+    default a new (more specific) format is prepended ahead of the permissive
+    ASP 3.x default.
+    """
+    if prepend:
+        ASP_LOG_FORMATS.insert(0, fmt)
+    else:
+        ASP_LOG_FORMATS.append(fmt)
+
+
+def select_format(banner_line):
+    """Return an adapter instance for a log whose first line is ``banner_line``.
+
+    Falls back to the default ASP 3.x adapter (with a warning) when no
+    registered format claims the banner, so an unrecognized version degrades
+    gracefully instead of dropping all fields.
+    """
+    for fmt in ASP_LOG_FORMATS:
+        if fmt.supports(banner_line):
+            return fmt()
+    logger.warning(
+        "Unrecognized ASP log banner %r; falling back to %s parsing.",
+        (banner_line or "").strip(),
+        DEFAULT_FORMAT.name,
+    )
+    return DEFAULT_FORMAT()
+
+
+class AspLog:
+    """A single ASP log file, parsed through the matching versioned adapter.
+
+    Reads the file once on construction and exposes the parsed fields as
+    properties. Selecting the adapter from the version banner means a caller
+    never needs to know which ASP version produced the log.
+    """
+
+    def __init__(self, path):
+        self.path = path
+        with open(path, "r") as f:
+            self.lines = f.read().splitlines()
+        banner = self.lines[0] if self.lines else ""
+        self.format = select_format(banner)
+
+    @property
+    def asp_version(self):
+        """The ASP version string, or ``None`` if the banner is absent."""
+        if not self.lines:
+            return None
+        return self.format.parse_version(self.lines[0])
+
+    @property
+    def command(self):
+        """The full command line (tool + args), or ``None`` if not found."""
+        result = self.format.parse_command_line(self.lines)
+        if result is None:
+            logger.warning("No ASP tool command line found in %s", self.path)
+            return None
+        return result[1]
+
+    @property
+    def tool(self):
+        """The executable basename of the invocation (e.g. ``stereo_tri``)."""
+        result = self.format.parse_command_line(self.lines)
+        return result[0] if result else None
+
+    def canonical_command(self, tool_name):
+        """Return the command line with its executable replaced by ``tool_name``.
+
+        ASP logs the executable as an absolute path (or a stage-specific name
+        like ``stereo_tri``); reports want a canonical, path-free invocation
+        such as ``bundle_adjust ...`` or ``stereo ...``. Returns ``None`` if no
+        command line was found.
+        """
+        command = self.command
+        if command is None:
+            return None
+        parts = command.split(maxsplit=1)
+        args = parts[1] if len(parts) > 1 else ""
+        return f"{tool_name} {args}".rstrip()
+
+    @property
+    def timestamps(self):
+        """All parsed console timestamps, in file order."""
+        out = []
+        for line in self.lines:
+            ts = self.format.parse_timestamp(line)
+            if ts is not None:
+                out.append(ts)
+        return out
+
+    @property
+    def first_timestamp(self):
+        """The earliest console timestamp, or ``None``."""
+        timestamps = self.timestamps
+        return timestamps[0] if timestamps else None
+
+    @property
+    def last_timestamp(self):
+        """The latest console timestamp, or ``None``."""
+        timestamps = self.timestamps
+        return timestamps[-1] if timestamps else None
+
+    @property
+    def reference_dem(self):
+        """The reference-DEM path announced in the log, or ``None``."""
+        return self.format.parse_reference_dem(self.lines)
+
+
+# Registered formats, tried in order; the first whose ``supports`` returns True
+# wins. Use :func:`register_format` to add more specific formats ahead of the
+# permissive ASP 3.x default.
+ASP_LOG_FORMATS = [AspLogFormat]
+DEFAULT_FORMAT = AspLogFormat

--- a/asp_plot/processing_parameters.py
+++ b/asp_plot/processing_parameters.py
@@ -1,9 +1,8 @@
 import glob
 import logging
 import os
-import re
-from datetime import datetime
 
+from asp_plot.asp_log import STEREO_STEP_ORDER, AspLog
 from asp_plot.utils import glob_file
 
 logging.basicConfig(level=logging.WARNING)
@@ -18,6 +17,11 @@ class ProcessingParameters:
     including bundle adjustment, stereo, and point2dem logs. It provides
     methods to parse these logs and obtain command lines, run times, and
     other relevant processing information.
+
+    All of the format-specific parsing (version banner, command line,
+    timestamps, reference DEM) is delegated to the versioned adapter in
+    :mod:`asp_plot.asp_log`, so this class stays focused on locating the right
+    log files and assembling the parameter dictionary.
 
     Attributes
     ----------
@@ -84,24 +88,46 @@ class ProcessingParameters:
         )
         self.processing_parameters_dict = {}
 
-        try:
-            self.bundle_adjust_log = glob_file(
-                self.full_ba_directory, "*log-bundle_adjust*.txt"
-            )
-        except:
-            self.bundle_adjust_log = None
-        try:
-            self.stereo_logs = glob.glob(
-                os.path.join(self.full_stereo_directory, "*log-stereo*.txt")
-            )
-        except:
-            self.stereo_logs = None
-        try:
-            self.point2dem_log = glob_file(
-                self.full_stereo_directory, "*log-point2dem*.txt"
-            )
-        except:
-            self.point2dem_log = None
+        # Locate log files. A missing directory (None) means that stage was not
+        # requested -- not an error -- so we guard on it rather than catching a
+        # blanket exception that would also hide real I/O problems.
+        self.bundle_adjust_log = (
+            glob_file(self.full_ba_directory, "*log-bundle_adjust*.txt")
+            if self.full_ba_directory
+            else None
+        )
+        self.stereo_logs = (
+            glob.glob(os.path.join(self.full_stereo_directory, "*log-stereo*.txt"))
+            if self.full_stereo_directory
+            else None
+        )
+        self.point2dem_log = (
+            glob_file(self.full_stereo_directory, "*log-point2dem*.txt")
+            if self.full_stereo_directory
+            else None
+        )
+
+    def _stereo_log(self, step):
+        """Return the stereo log for a given pipeline ``step``, or None.
+
+        ``step`` is a name from :data:`asp_plot.asp_log.STEREO_STEP_ORDER`
+        (e.g. ``"stereo_pprc"``).
+        """
+        if not self.stereo_logs:
+            return None
+        return next(
+            (log for log in self.stereo_logs if f"log-{step}" in log),
+            None,
+        )
+
+    def _ordered_stereo_logs(self):
+        """Return present stereo logs as ``(step, path)`` in pipeline order."""
+        ordered = []
+        for step in STEREO_STEP_ORDER:
+            log = self._stereo_log(step)
+            if log:
+                ordered.append((step, log))
+        return ordered
 
     def get_asp_version(self):
         """Extract the ASP version string from the first available log file.
@@ -114,24 +140,20 @@ class ProcessingParameters:
         log_candidates = []
         if self.bundle_adjust_log:
             log_candidates.append(self.bundle_adjust_log)
-        if self.stereo_logs:
-            pprc = next(
-                (log for log in self.stereo_logs if "log-stereo_pprc" in log),
-                None,
-            )
-            if pprc:
-                log_candidates.append(pprc)
+        pprc = self._stereo_log("stereo_pprc")
+        if pprc:
+            log_candidates.append(pprc)
         if self.point2dem_log:
             log_candidates.append(self.point2dem_log)
 
         for log_file in log_candidates:
             try:
-                with open(log_file, "r") as f:
-                    first_line = f.readline().strip()
-                if first_line.startswith("ASP "):
-                    return first_line[4:]
-            except Exception:
+                version = AspLog(log_file).asp_version
+            except OSError as e:
+                logger.warning("Could not read %s for ASP version: %s", log_file, e)
                 continue
+            if version:
+                return version
         return "N/A"
 
     def from_log_files(self):
@@ -164,7 +186,7 @@ class ProcessingParameters:
             bundle_adjust_params, ba_run_time, reference_dem = (
                 self.from_bundle_adjust_log()
             )
-            if reference_dem != "":
+            if reference_dem:
                 processing_timestamp, stereo_params, stereo_run_time = (
                     self.from_stereo_log()
                 )
@@ -172,9 +194,6 @@ class ProcessingParameters:
                 processing_timestamp, stereo_params, stereo_run_time, reference_dem = (
                     self.from_stereo_log(search_for_reference_dem=True)
                 )
-            bundle_adjust_params = (
-                "bundle_adjust " + bundle_adjust_params.split(maxsplit=1)[1]
-            )
         else:
             bundle_adjust_params = "Bundle adjustment not run"
             ba_run_time = "N/A"
@@ -183,9 +202,6 @@ class ProcessingParameters:
             )
 
         point2dem_params, point2dem_run_time = self.from_point2dem_log()
-
-        stereo_params = "stereo " + stereo_params.split(maxsplit=1)[1]
-        point2dem_params = "point2dem " + point2dem_params.split(maxsplit=1)[1]
 
         self.processing_parameters_dict = {
             "asp_version": self.get_asp_version(),
@@ -213,9 +229,9 @@ class ProcessingParameters:
         tuple
             A tuple containing (bundle_adjust_params, run_time, reference_dem)
             where:
-            - bundle_adjust_params: str, the bundle adjustment command line
+            - bundle_adjust_params: str, the canonical ``bundle_adjust`` command
             - run_time: str, formatted run time (e.g., "2 hours and 15 minutes")
-            - reference_dem: str, path to the reference DEM used
+            - reference_dem: str, path to the reference DEM used ("" if none)
 
         Raises
         ------
@@ -226,17 +242,9 @@ class ProcessingParameters:
             raise ValueError(
                 f"\n\nCould not find bundle adjust log file in {self.full_ba_directory}\nCheck that the *log*.txt file exists in the directory specified.\n\n"
             )
-        bundle_adjust_params = ""
-        with open(self.bundle_adjust_log, "r") as file:
-            for line in file:
-                if "bundle_adjust" in line and not bundle_adjust_params:
-                    bundle_adjust_params = line.strip()
-                    break
-
-        reference_dem = self.get_reference_dem(
-            self.bundle_adjust_log, starting_string="Loading DEM:"
-        )
-
+        log = AspLog(self.bundle_adjust_log)
+        bundle_adjust_params = log.canonical_command("bundle_adjust")
+        reference_dem = log.reference_dem or ""
         run_time = self.get_run_time([self.bundle_adjust_log])
 
         return bundle_adjust_params, run_time, reference_dem
@@ -252,7 +260,7 @@ class ProcessingParameters:
         -------
         tuple
             A tuple containing (point2dem_params, run_time) where:
-            - point2dem_params: str, the point2dem command line
+            - point2dem_params: str, the canonical ``point2dem`` command line
             - run_time: str, formatted run time (e.g., "0 hours and 45 minutes")
 
         Raises
@@ -264,13 +272,7 @@ class ProcessingParameters:
             raise ValueError(
                 f"\n\nCould not find point2dem log file in {self.full_stereo_directory}\nCheck that the *log*.txt file exists in the directory specified.\n\n"
             )
-        point2dem_params = ""
-        with open(self.point2dem_log, "r") as file:
-            for line in file:
-                if "point2dem" in line and not point2dem_params:
-                    point2dem_params = line.strip()
-                    break
-
+        point2dem_params = AspLog(self.point2dem_log).canonical_command("point2dem")
         run_time = self.get_run_time([self.point2dem_log])
 
         return point2dem_params, run_time
@@ -280,9 +282,11 @@ class ProcessingParameters:
         Extract parameters from the stereo log files.
 
         Parses the stereo log files to extract command lines, processing timestamp,
-        and optionally searches for reference DEM information. This method uses
-        both the preprocessing (pprc) and triangulation (tri) logs to get
-        start/end times and stereo parameters.
+        and optionally searches for reference DEM information. The earliest and
+        latest stereo stages present (per
+        :data:`asp_plot.asp_log.STEREO_STEP_ORDER`) bracket the run, so the
+        command/reference DEM come from the final stage and the run-time span
+        from first-stage start to last-stage end.
 
         Parameters
         ----------
@@ -295,11 +299,11 @@ class ProcessingParameters:
             If search_for_reference_dem is False, returns:
             (processing_timestamp, stereo_params, run_time) where:
             - processing_timestamp: datetime, when processing started
-            - stereo_params: str, the stereo command line
+            - stereo_params: str, the canonical ``stereo`` command line
             - run_time: str, formatted run time
 
             If search_for_reference_dem is True, additionally returns:
-            - reference_dem: str, path to the reference DEM used
+            - reference_dem: str, path to the reference DEM used ("" if none)
 
         Raises
         ------
@@ -316,66 +320,47 @@ class ProcessingParameters:
         5. stereo_fltr - filtering
         6. stereo_tri - triangulation
 
-        This method uses the pprc log for start time and the tri log for
-        end time to calculate total runtime.
+        This method uses the first stage's log for the start time and the last
+        stage's log for the end time to calculate total runtime.
         """
-        # Stereo proceeds as:
-        #  1. stereo_pprc
-        #  2. stereo_corr
-        #  3. stereo_blend (logs in tile/ dirs)
-        #  4. stereo_rfne (logs in tile/ dirs)
-        #  5. stereo_fltr
-        #  6. stereo_tri
         if not self.stereo_logs:
             raise ValueError(
                 f"\n\nCould not find stereo log files in {self.full_stereo_directory}\nCheck that these *log*.txt files exist in the directory specified.\n\n"
             )
-        pprc_log = next(
-            (log for log in self.stereo_logs if "log-stereo_pprc" in log), None
-        )
-        tri_log = next(
-            (log for log in self.stereo_logs if "log-stereo_tri" in log), None
-        )
-        stereo_params = ""
-        with open(tri_log, "r") as file:
-            for line in file:
-                if "stereo" in line and not stereo_params:
-                    stereo_params = line.strip()
-                    break
+        ordered = self._ordered_stereo_logs()
+        if not ordered:
+            raise ValueError(
+                f"\n\nCould not match any known stereo stage in {self.full_stereo_directory}\nExpected logs such as log-stereo_pprc*.txt ... log-stereo_tri*.txt.\n\n"
+            )
+        first_log = ordered[0][1]
+        last_log = ordered[-1][1]
 
-        processing_timestamp = ""
-        with open(pprc_log, "r") as file:
-            for line in file:
-                if re.match(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}", line):
-                    processing_timestamp = datetime.strptime(
-                        line.split()[0] + " " + line.split()[1], "%Y-%m-%d %H:%M:%S"
-                    )
+        last_stage_log = AspLog(last_log)
+        stereo_params = last_stage_log.canonical_command("stereo")
 
-        run_time = self.get_run_time([pprc_log, tri_log])
+        # processing_timestamp mirrors historical behavior: the last console
+        # timestamp recorded in the first stage's (pprc) log.
+        processing_timestamp = AspLog(first_log).last_timestamp or ""
+
+        run_time = self.get_run_time([first_log, last_log])
 
         if search_for_reference_dem:
-            reference_dem = self.get_reference_dem(
-                pprc_log, starting_string="Input DEM:"
-            )
-
+            reference_dem = last_stage_log.reference_dem
+            if not reference_dem:
+                # Fall back to the first stage (pprc announces "Using input DEM:").
+                reference_dem = AspLog(first_log).reference_dem or ""
             return processing_timestamp, stereo_params, run_time, reference_dem
         else:
             return processing_timestamp, stereo_params, run_time
 
-    def get_reference_dem(self, logfile, starting_string="DEM:"):
+    def get_reference_dem(self, logfile):
         """
         Extract reference DEM path from a log file.
-
-        Searches for the reference DEM path in a log file using a
-        pattern matching approach.
 
         Parameters
         ----------
         logfile : str
             Path to the log file to search
-        starting_string : str, optional
-            String pattern that precedes the DEM path in the log,
-            default is "DEM:"
 
         Returns
         -------
@@ -384,18 +369,10 @@ class ProcessingParameters:
 
         Notes
         -----
-        This is a helper method used by from_bundle_adjust_log and
-        from_stereo_log to extract reference DEM information.
-        Different log file types use different patterns to indicate
-        reference DEMs, hence the configurable starting_string parameter.
+        Parsing is delegated to the versioned adapter, which recognizes the
+        known ASP phrasings ("Loading DEM:", "Using input DEM:", "Input DEM:").
         """
-        reference_dem = ""
-        pattern = re.compile(starting_string, re.IGNORECASE)
-        with open(logfile, "r") as file:
-            for line in file:
-                if pattern.search(line):
-                    reference_dem = pattern.split(line)[1].strip()
-        return reference_dem
+        return AspLog(logfile).reference_dem or ""
 
     def get_run_time(self, logfiles):
         """
@@ -426,26 +403,11 @@ class ProcessingParameters:
         If only one log file is provided, it will be used for both
         start and end times. This is useful for single-stage processes.
         """
-        start_time = None
-        end_time = None
-
         start_log = logfiles[0]
         end_log = logfiles[-1] if len(logfiles) > 1 else start_log
 
-        with open(start_log, "r") as file:
-            for line in file:
-                if re.match(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}", line):
-                    start_time = datetime.strptime(
-                        line.split()[0] + " " + line.split()[1], "%Y-%m-%d %H:%M:%S"
-                    )
-                    break
-
-        with open(end_log, "r") as file:
-            for line in file:
-                if re.match(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}", line):
-                    end_time = datetime.strptime(
-                        line.split()[0] + " " + line.split()[1], "%Y-%m-%d %H:%M:%S"
-                    )
+        start_time = AspLog(start_log).first_timestamp
+        end_time = AspLog(end_log).last_timestamp
 
         if start_time and end_time:
             time_diff = end_time - start_time

--- a/tests/test_asp_log.py
+++ b/tests/test_asp_log.py
@@ -1,0 +1,133 @@
+import re
+from datetime import datetime
+
+import pytest
+
+from asp_plot import asp_log
+from asp_plot.asp_log import AspLog, AspLogFormat, select_format
+
+BA_LOG = "tests/test_data/ba/log-bundle_adjust.txt"
+PPRC_LOG = "tests/test_data/stereo/log-stereo_pprc.txt"
+TRI_LOG = "tests/test_data/stereo/log-stereo_tri.txt"
+POINT2DEM_LOG = "tests/test_data/stereo/log-point2dem.txt"
+
+VARIANT_LOG = "tests/test_data/asp_log_variant/log-bundle_adjust-variant.txt"
+
+
+class TestAspLog3x:
+    """Adapter behavior against the real ASP 3.4.0-alpha fixtures."""
+
+    def test_version(self):
+        assert AspLog(BA_LOG).asp_version == "3.4.0-alpha"
+        assert AspLog(PPRC_LOG).asp_version == "3.4.0-alpha"
+
+    def test_tool_detection_by_basename(self):
+        # bundle_adjust is logged as an absolute path; the executable basename
+        # is what identifies it -- not an arbitrary substring.
+        assert AspLog(BA_LOG).tool == "bundle_adjust"
+        assert AspLog(TRI_LOG).tool == "stereo_tri"
+        assert AspLog(POINT2DEM_LOG).tool == "point2dem"
+
+    def test_canonical_command_strips_executable_path(self):
+        cmd = AspLog(BA_LOG).canonical_command("bundle_adjust")
+        assert cmd.startswith("bundle_adjust -t dg ")
+        # No absolute executable path leaks into the canonical command.
+        assert "/libexec/bundle_adjust" not in cmd
+
+    def test_canonical_command_renames_stage(self):
+        # stereo_tri's invocation is canonicalized to a path-free "stereo ...".
+        cmd = AspLog(TRI_LOG).canonical_command("stereo")
+        assert cmd.startswith("stereo --stereo-algorithm asp_mgm ")
+
+    def test_timestamps_first_last(self):
+        log = AspLog(PPRC_LOG)
+        assert log.first_timestamp == datetime(2024, 4, 14, 17, 14, 31)
+        assert log.last_timestamp == datetime(2024, 4, 14, 17, 55, 43)
+        assert log.first_timestamp <= log.last_timestamp
+
+    def test_reference_dem_loading(self):
+        # bundle_adjust announces "Loading DEM:".
+        assert (
+            AspLog(BA_LOG).reference_dem
+            == "/nobackup/bpurint1/data/utqiagvik/COP/COP30_utqiagvik_lzw-adj_proj.tif"
+        )
+
+    def test_reference_dem_using_input(self):
+        # stereo_pprc announces "Using input DEM:" -- a different phrasing that
+        # the single unified pattern still handles.
+        assert (
+            AspLog(PPRC_LOG).reference_dem
+            == "/nobackup/bpurint1/data/utqiagvik/COP/COP30_utqiagvik_lzw-adj_proj.tif"
+        )
+
+    def test_format_selected_is_3x(self):
+        assert isinstance(select_format("ASP 3.4.0-alpha"), AspLogFormat)
+        assert select_format("ASP 3.4.0-alpha").name == "asp-3.x"
+
+
+class TestFallback:
+    def test_unrecognized_banner_falls_back_to_default(self):
+        # An unknown banner does not raise; it degrades to the default adapter.
+        fmt = select_format("totally unexpected first line")
+        assert isinstance(fmt, AspLogFormat)
+
+    def test_missing_command_returns_none_not_raise(self, tmp_path):
+        log_path = tmp_path / "log-empty.txt"
+        log_path.write_text("ASP 3.4.0-alpha\nBuild ID: x\n\nno command here\n")
+        log = AspLog(str(log_path))
+        assert log.command is None
+        assert log.canonical_command("stereo") is None
+
+
+# --- Format-variant adapter: proves the registry/dispatch is not vacuous. ---
+#
+# A synthetic future "ASP-NG" layout that drifts in three ways at once:
+#   * banner word ("ASP-NG" instead of "ASP")
+#   * ISO-8601 timestamps with a "T" separator
+#   * reference DEM phrased as "Reference DEM:"
+# Only the changed pieces are overridden, demonstrating the intended extension
+# pattern for real ASP format drift.
+class _VariantFormat(AspLogFormat):
+    name = "asp-ng-4.x"
+    version_banner_re = re.compile(r"^ASP-NG\s+(?P<version>\S+)")
+    timestamp_re = re.compile(r"^(?P<ts>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})")
+    timestamp_fmt = "%Y-%m-%dT%H:%M:%S"
+    reference_dem_re = re.compile(r"Reference DEM\s*:\s*(?P<dem>\S+)", re.IGNORECASE)
+
+    @classmethod
+    def supports(cls, banner_line):
+        match = cls.version_banner_re.match(banner_line or "")
+        return bool(match) and match.group("version").startswith("4.")
+
+
+@pytest.fixture
+def variant_registered():
+    asp_log.register_format(_VariantFormat)
+    try:
+        yield
+    finally:
+        asp_log.ASP_LOG_FORMATS.remove(_VariantFormat)
+
+
+class TestFormatVariant:
+    def test_default_does_not_claim_variant_banner(self):
+        # Without the variant adapter registered, the ASP-NG banner is
+        # unrecognized and falls back to the default (no version parsed).
+        assert AspLogFormat.supports("ASP-NG 4.1.0") is False
+
+    def test_variant_adapter_selected_and_parses(self, variant_registered):
+        log = AspLog(VARIANT_LOG)
+        assert log.format.name == "asp-ng-4.x"
+        assert log.asp_version == "4.1.0"
+        # ISO-8601 "T"-separated timestamps parse through the overridden format.
+        assert log.first_timestamp == datetime(2025, 6, 1, 8, 0, 0)
+        assert log.last_timestamp == datetime(2025, 6, 1, 8, 7, 30)
+        # "Reference DEM:" phrasing handled by the overridden pattern.
+        assert log.reference_dem == "/data/ref/cop30_variant.tif"
+        # Tool detection by basename is format-independent.
+        assert log.tool == "bundle_adjust"
+        assert log.canonical_command("bundle_adjust").startswith("bundle_adjust -t dg ")
+
+    def test_registration_is_isolated(self, variant_registered):
+        # Inside the fixture the variant is registered...
+        assert _VariantFormat in asp_log.ASP_LOG_FORMATS

--- a/tests/test_data/asp_log_variant/log-bundle_adjust-variant.txt
+++ b/tests/test_data/asp_log_variant/log-bundle_adjust-variant.txt
@@ -1,0 +1,12 @@
+ASP-NG 4.1.0
+Build ID: deadbeef
+Build date: 2025-05-30
+
+/opt/asp-ng/libexec/bundle_adjust -t dg --datum WGS84 --ip-per-tile 50 left.tif right.tif left.xml right.xml -o ba/run --threads 16
+
+uname -a
+Linux variant-host 6.1.0 #1 SMP x86_64 GNU/Linux
+
+2025-06-01T08:00:00 [ console ] : Starting bundle adjustment.
+2025-06-01T08:00:05 [ console ] : Reference DEM: /data/ref/cop30_variant.tif
+2025-06-01T08:07:30 [ console ] : Finished bundle adjustment.

--- a/tests/test_data/asp_log_variant/log-bundle_adjust-variant.txt
+++ b/tests/test_data/asp_log_variant/log-bundle_adjust-variant.txt
@@ -1,5 +1,5 @@
 ASP-NG 4.1.0
-Build ID: deadbeef
+Build ID: foobar
 Build date: 2025-05-30
 
 /opt/asp-ng/libexec/bundle_adjust -t dg --datum WGS84 --ip-per-tile 50 left.tif right.tif left.xml right.xml -o ba/run --threads 16

--- a/tests/test_processing_parameters.py
+++ b/tests/test_processing_parameters.py
@@ -2,6 +2,52 @@ import pytest
 
 from asp_plot.processing_parameters import ProcessingParameters
 
+# Golden values pinned from the real ASP 3.4.0-alpha log fixtures under
+# tests/test_data/{ba,stereo}/. These lock in the exact parsed output before
+# the #132 refactor moves log parsing behind a versioned adapter, so any
+# behavioral drift in command/timestamp/DEM extraction is caught.
+GOLDEN_PARAMETERS = {
+    "asp_version": "3.4.0-alpha",
+    "processing_timestamp": "2024-04-14 17:55:43",
+    "reference_dem": "/nobackup/bpurint1/data/utqiagvik/COP/COP30_utqiagvik_lzw-adj_proj.tif",
+    "bundle_adjust": (
+        "bundle_adjust -t dg --weight-image /nobackup/bpurint1/data/utqiagvik/WV/"
+        "utqiagvik_wv_EE/2022/utqiagvik_10m_UTM4N_seaice_mask_0and1.tif --datum WGS84 "
+        "--individually-normalize --normalize-ip-tiles --ip-per-tile 50 "
+        "--matches-per-tile 10 --min-triangulation-angle 10 --mapproj-dem "
+        "/nobackup/bpurint1/data/utqiagvik/COP/COP30_utqiagvik_lzw-adj_proj.tif "
+        "--propagate-errors --tri-weight 0.1 --tri-robust-threshold 0.1 "
+        "--camera-weight 0 10300100D12D7400.r100.tif 10300100D0772D00.r100.tif "
+        "10300100D12D7400.r100.xml 10300100D0772D00.r100.xml -o "
+        "ba/ba_50ips_10matches_dg_weight_image --threads 28"
+    ),
+    "bundle_adjust_run_time": "0 hours and 3 minutes",
+    "stereo": (
+        "stereo --stereo-algorithm asp_mgm --corr-kernel 7 7 --subpixel-kernel 15 15 "
+        "--cost-mode 4 --subpixel-mode 9 --corr-max-levels 5 --filter-mode 1 "
+        "--erode-max-size 0 --individually-normalize --corr-memory-limit-mb 5000 "
+        "--sgm-collar-size 256 --corr-tile-size 1024 --alignment-method none "
+        "--corr-seed-mode 1 --compute-point-cloud-center-only --threads 24 "
+        "1040010074793300_ortho_0.35m.tif 1040010075633C00_ortho_0.35m.tif "
+        "ba/ba_50ips_10matches_dg_weight_image-1040010074793300.r100.adjusted_state.json "
+        "ba/ba_50ips_10matches_dg_weight_image-1040010075633C00.r100.adjusted_state.json "
+        "stereo/20220417_2252_1040010074793300_1040010075633C00 "
+        "/nobackup/bpurint1/data/utqiagvik/COP/COP30_utqiagvik_lzw-adj_proj.tif"
+    ),
+    "stereo_run_time": "3 hours and 41 minutes",
+    "point2dem": (
+        "point2dem --nodata-value -9999 --t_srs EPSG:32604 --threads 24 "
+        "--propagate-errors --remove-outliers --remove-outliers-params 75.0 3.0 "
+        "--errorimage --tr 1 -o stereo_ba_50ips_10matches_dg_weight_image__ortho_0.55m"
+        "_mode_asp_mgm_spm_9_corr_7_rfne_15_cost_4_refdem_COP30/"
+        "20220419_2321_10300100D12D7400_10300100D0772D00_1m "
+        "stereo_ba_50ips_10matches_dg_weight_image__ortho_0.55m_mode_asp_mgm_spm_9_"
+        "corr_7_rfne_15_cost_4_refdem_COP30/"
+        "20220419_2321_10300100D12D7400_10300100D0772D00-PC.tif"
+    ),
+    "point2dem_run_time": "0 hours and 14 minutes",
+}
+
 
 class TestProcessingParameters:
     @pytest.fixture
@@ -50,3 +96,11 @@ class TestProcessingParameters:
         result = processing_parameters_no_ba.from_log_files()
         assert result["bundle_adjust"] == "Bundle adjustment not run"
         assert result["bundle_adjust_run_time"] == "N/A"
+
+    def test_from_log_files_golden(self, processing_parameters):
+        # Characterization: pin the exact parsed output of every field against
+        # the real ASP 3.4.0-alpha log fixtures.
+        result = processing_parameters.from_log_files()
+        assert set(result.keys()) == set(GOLDEN_PARAMETERS.keys())
+        for key, expected in GOLDEN_PARAMETERS.items():
+            assert str(result[key]) == expected, f"drift in field {key!r}"


### PR DESCRIPTION
Closes #132. Part of the structural rewrite tracked in #122.

## What

Replaces the brittle, hardcoded ASP-log string surgery in `processing_parameters.py` with a small **versioned adapter** in a new `asp_log.py` module — the same "format-specific schema behind a stable interface" pattern as the sensor-metadata parser (#25).

### `asp_plot/asp_log.py` (new)
- **`AspLogFormat`** — adapter describing one ASP log layout (base class = the current ASP 3.x format). Version banner, timestamps, command line, and reference DEM each parse through documented, overridable patterns.
  - Command lines are located by the **executable basename** (matched against `ASP_TOOL_NAMES`), not by an arbitrary `"bundle_adjust" in line` substring — and timestamped console lines are skipped, so a later log line mentioning the tool can't be mistaken for the invocation.
  - One unified, case-insensitive reference-DEM pattern handles every known phrasing (`Loading DEM:`, `Using input DEM:`, `Input DEM:`) instead of caller-supplied magic strings.
- **`AspLog`** — reads one log file and exposes `asp_version`, `command`, `tool`, `canonical_command(name)`, `first/last_timestamp`, `reference_dem`.
- **`select_format` / `register_format`** — a registry keyed by the version banner. Unrecognized banners **fall back to the default adapter with a warning**; `register_format()` is the documented extension point for future ASP format drift.

### `asp_plot/processing_parameters.py`
- Delegates **all** parsing to `AspLog` — no more `line.split()[0]`, `split(maxsplit=1)` surgery, or inline timestamp regexes.
- **Bare `except:` clauses removed.** `__init__` guards on whether each stage directory was requested (a missing stage is not an error); parse failures now return `None`/`"N/A"` and **log** instead of silently dropping fields.
- Stereo step ordering generalized via `STEREO_STEP_ORDER` (earliest/latest stage *present*) instead of hardcoding `pprc`→`tri`.
- Public method signatures (`from_log_files`, `from_stereo_log`, `get_reference_dem`, `get_run_time`, …) preserved, so `stereo.py`, `bundle_adjust.py`, and `report_pipeline.py` are untouched.

## Acceptance criteria
- [x] Log parsing behind an adapter interface keyed by tool/version
- [x] No bare `except:`; parse failures are logged, not swallowed
- [x] `test_processing_parameters.py` green; fixture added for a format variant

## Testing
- **Characterization first:** added `test_from_log_files_golden` pinning every parsed field against the real ASP 3.4.0-alpha fixtures (committed *before* the refactor); still green after.
- New `tests/test_asp_log.py` (14 tests): real-fixture parsing, fallback/`None` behavior, plus a **registered drifted-format variant** (new `tests/test_data/asp_log_variant/` fixture: `ASP-NG 4.1.0` banner, ISO-8601 `T` timestamps, `Reference DEM:` phrasing) proving the registry actually dispatches.
- Full suite: **292 passed** (was 278). black / isort / flake8 clean.
