### PR TITLE
Finish the Altimetry source split: decompose ATL06-SR request + AltimetrySource subclasses (#140)

### DIFF
--- a/asp_plot/altimetry.py
+++ b/asp_plot/altimetry.py
@@ -33,10 +33,12 @@ from asp_plot.bodies import BODIES
 from asp_plot.icesat2_source import ICESAT2_MISSION_START, Icesat2Source  # noqa: F401
 from asp_plot.planetary_source import (  # noqa: F401
     GDS_BASE_URL,
+    LolaSource,
+    MolaSource,
     PlanetarySource,
     gds_query_async,
 )
-from asp_plot.utils import Raster, glob_file
+from asp_plot.utils import Raster, detect_planetary_body, glob_file
 
 logging.basicConfig(level=logging.WARNING)
 logger = logging.getLogger(__name__)
@@ -174,7 +176,13 @@ class Altimetry:
             atl06sr_processing_levels=atl06sr_processing_levels,
             atl06sr_processing_levels_filtered=atl06sr_processing_levels_filtered,
         )
-        self.planetary = PlanetarySource(self)
+        # Pick the planetary source from the DEM's body so LOLA/MOLA loading is
+        # dispatched once, at construction. Earth DEMs get the body-agnostic
+        # base (its load_planetary_csv raises, redirecting to ICESat-2).
+        planetary_cls = {"moon": LolaSource, "mars": MolaSource}.get(
+            detect_planetary_body(dem_fn), PlanetarySource
+        )
+        self.planetary = planetary_cls(self)
         self.plotter = AltimetryPlotter(self)
 
     # ------------------------------------------------------------------ #

--- a/asp_plot/altimetry.py
+++ b/asp_plot/altimetry.py
@@ -7,7 +7,9 @@ objects and exposes their behaviour under one notebook-friendly API:
   caching, WorldCover sampling, temporal/outlier filtering, DEM differencing,
   and track/segment selection.
 - :class:`asp_plot.planetary_source.PlanetarySource` — LOLA/MOLA loading and
-  DEM differencing.
+  DEM differencing, via the per-body :class:`~asp_plot.planetary_source.LolaSource`
+  / :class:`~asp_plot.planetary_source.MolaSource` subclasses selected from the
+  DEM's body at construction.
 - :class:`asp_plot.altimetry_plots.AltimetryPlotter` — all figure rendering,
   operating on prepared dataframes.
 
@@ -92,8 +94,9 @@ class Altimetry:
     Process and analyze ICESat-2 / planetary altimetry against ASP DEMs.
 
     Coordinates the ICESat-2 (:class:`Icesat2Source`) and planetary
-    (:class:`PlanetarySource`) data sources and the plotting layer
-    (:class:`AltimetryPlotter`), exposing them under a single API. It can
+    (:class:`PlanetarySource`, i.e. :class:`LolaSource` / :class:`MolaSource`)
+    data sources and the plotting layer (:class:`AltimetryPlotter`), exposing
+    them under a single API. It can
     request and filter altimetry data, align a DEM to it, and visualize the
     results.
 

--- a/asp_plot/altimetry_source.py
+++ b/asp_plot/altimetry_source.py
@@ -1,0 +1,101 @@
+"""Shared base for the altimetry sources.
+
+Every altimetry source — ICESat-2 on Earth (:class:`Icesat2Source`) and the
+planetary instruments LOLA/MOLA (:class:`LolaSource` / :class:`MolaSource`) —
+samples an ASP DEM at a set of point locations, differences the altimetry
+heights against it, removes coarse outliers, and exports a pc_align-ready CSV.
+:class:`AltimetrySource` collects that shared machinery so each concrete source
+only carries what is genuinely body-specific (the request/loader and the
+height/datum conventions).
+
+Sources hold a back reference to the coordinating
+:class:`asp_plot.altimetry.Altimetry` instance and read the cross-cutting
+``dem_fn`` / ``directory`` / ``aligned_dem_fn`` from it, so a single source of
+truth describes the DEM under analysis.
+"""
+
+import os
+
+import numpy as np
+import rioxarray
+import xarray as xr
+
+
+class AltimetrySource:
+    """Base for ICESat-2 and planetary altimetry sources.
+
+    Parameters
+    ----------
+    alt : Altimetry
+        The coordinating :class:`asp_plot.altimetry.Altimetry` instance.
+    """
+
+    def __init__(self, alt):
+        self.alt = alt
+
+    @staticmethod
+    def _interp_dem_at_points(dem, points):
+        """Bilinear-interpolate an open DEM at GeoDataFrame point locations.
+
+        Parameters
+        ----------
+        dem : xarray.DataArray
+            A DEM already opened (and squeezed) with rioxarray. Opening once
+            and interpolating many times keeps the per-key ICESat-2 loop and
+            the raw/aligned planetary passes from re-reading the raster.
+        points : geopandas.GeoDataFrame
+            Points to sample. Reprojected to the DEM CRS internally.
+
+        Returns
+        -------
+        tuple of (numpy.ndarray, geopandas.GeoDataFrame)
+            The sampled DEM values and the points reprojected to the DEM CRS.
+            Callers that need the reprojected geometry (ICESat-2 stores it so
+            downstream track geometry is in the DEM/working CRS) use the second
+            element; the planetary path samples a throwaway copy and ignores it.
+        """
+        pts = points.to_crs(dem.rio.crs)
+        x = xr.DataArray(pts.geometry.x.values, dims="z")
+        y = xr.DataArray(pts.geometry.y.values, dims="z")
+        sampled = dem.interp(x=x, y=y).values
+        return sampled, pts
+
+    @staticmethod
+    def _open_dem(dem_fn):
+        """Open a DEM as a squeezed, masked :class:`xarray.DataArray`."""
+        return rioxarray.open_rasterio(dem_fn, masked=True).squeeze()
+
+    @staticmethod
+    def _std_outlier_mask(dh, n_sigma):
+        """Boolean mask keeping dh values within ``n_sigma`` × std of the mean.
+
+        Rows whose ``dh`` is NaN are kept (they carry no difference yet and
+        must not be dropped). Returns ``None`` when the spread is degenerate
+        (zero or non-finite std), signalling that no filtering should occur.
+
+        Parameters
+        ----------
+        dh : pandas.Series
+            Height differences (may contain NaN).
+        n_sigma : float
+            Number of standard deviations to allow about the mean.
+        """
+        valid = dh.dropna().values
+        if valid.size == 0:
+            return None
+        mean_val = np.mean(valid)
+        std_val = np.std(valid)
+        if std_val == 0 or np.isnan(std_val):
+            return None
+        mask = (dh - mean_val).abs() <= n_sigma * std_val
+        return mask | dh.isna()
+
+    def _write_csv_to_directory(self, df, filename):
+        """Write ``df`` to ``filename`` under the coordinator's directory.
+
+        Returns the path written. Used by the pc_align CSV exporters, whose
+        only difference is the columns they select.
+        """
+        csv_fn = os.path.join(self.alt.directory, filename)
+        df.to_csv(csv_fn, header=True, index=False)
+        return csv_fn

--- a/asp_plot/altimetry_source.py
+++ b/asp_plot/altimetry_source.py
@@ -70,8 +70,9 @@ class AltimetrySource:
         """Boolean mask keeping dh values within ``n_sigma`` × std of the mean.
 
         Rows whose ``dh`` is NaN are kept (they carry no difference yet and
-        must not be dropped). Returns ``None`` when the spread is degenerate
-        (zero or non-finite std), signalling that no filtering should occur.
+        must not be dropped). Returns ``None`` — signalling that no filtering
+        should occur — when there are no finite values or the spread is
+        degenerate (zero or non-finite std).
 
         Parameters
         ----------

--- a/asp_plot/icesat2_source.py
+++ b/asp_plot/icesat2_source.py
@@ -283,6 +283,45 @@ class Icesat2Source:
             t0=t0,
             t1=t1,
         )
+        self._print_time_filter_summary(
+            time_range, t0_str, t1_str, resolved_date, t0, time_buffer_days
+        )
+
+        # Build the per-level SlideRule parameter sets (shared + custom).
+        level_parms = self._build_level_parms(
+            processing_levels, region, t0_str, t1_str, res, len, ats, maxi, cnt
+        )
+
+        # Record the request settings + cache locations so a report run can
+        # write them to a figure-selections file for reproducibility (#121).
+        self.atl06sr_request_parms = {
+            "processing_levels": list(processing_levels),
+            "res": res,
+            "len": len,
+            "ats": ats,
+            "time_range": time_range,
+            "t0": t0_str,
+            "t1": t1_str,
+        }
+        self.atl06sr_parquet_paths = {}
+
+        for key, parms in level_parms.items():
+            print(f"\nICESat-2 ATL06 request processing for: {key}")
+            fn = os.path.join(self.alt.directory, f"{filename}_{key}.parquet")
+            self.atl06sr_parquet_paths[key] = fn
+            print(parms)
+
+            atl06sr = self._load_cached_atl06sr(fn, parms)
+            if atl06sr is None:
+                atl06sr = self._request_atl06sr_level(parms, fn, save_to_parquet)
+
+            self._ingest_atl06sr(key, atl06sr, h_sigma_quantile)
+
+    @staticmethod
+    def _print_time_filter_summary(
+        time_range, t0_str, t1_str, resolved_date, t0, time_buffer_days
+    ):
+        """Print the resolved server-side time filter, matching the request cascade."""
         if time_range == "all" and resolved_date is None and t0 is None:
             print(f"Time filter: {t0_str} to {t1_str} (all available)")
         elif resolved_date is not None:
@@ -295,19 +334,23 @@ class Icesat2Source:
         else:
             print(f"Time filter: {t0_str} to {t1_str} (all available, fallback)")
 
-        # See parameter discussion on: https://github.com/SlideRuleEarth/sliderule/issues/448
-        # "srt": -1 tells the server side code to look at the ATL03 confidence array for each photon
-        # and choose the confidence level that is highest across all five surface type entries.
-        # cnf options: {"atl03_tep", "atl03_not_considered", "atl03_background", "atl03_within_10m", \
-        # "atl03_low", "atl03_medium", "atl03_high"}
-        # Note reduced count for limited number of ground photons
+    @staticmethod
+    def _build_level_parms(
+        processing_levels, region, t0_str, t1_str, res, len, ats, maxi, cnt
+    ):
+        """Build the merged SlideRule parameter dict for each requested level.
 
-        # TODO: use the WorldCover values to determine if we should report canopy or top of canopy
-        #   This is tricky, and not clear yet how to go about this. For now, just request all processing levels.
+        Returns ``{level_key: parms}`` where ``parms`` is the shared request
+        envelope merged with the level-specific confidence/surface-type
+        settings. Only levels in ``processing_levels`` are included.
 
-        # TODO: Use more generic variable names and strings for functions that are not just limited to atl06
-        #   This can be done when we implement additional requests for other data types
-
+        See the SlideRule parameter discussion at
+        https://github.com/SlideRuleEarth/sliderule/issues/448 — ``"srt": -1``
+        tells the server to choose, per photon, the highest ATL03 confidence
+        across all five surface-type entries. ``cnf`` options are
+        ``atl03_{tep,not_considered,background,within_10m,low,medium,high}``.
+        Ground uses a reduced ``cnt`` because ground photons are sparser.
+        """
         # Shared parameters for all processing levels
         shared_parms = {
             "poly": region,
@@ -346,76 +389,71 @@ class Icesat2Source:
             },
         }
 
-        # Filter custom_parms to only include requested processing levels
-        custom_parms = {
-            key: parms
+        return {
+            key: {**shared_parms, **parms}
             for key, parms in custom_parms.items()
             if key in processing_levels
         }
 
-        # Record the request settings + cache locations so a report run can
-        # write them to a figure-selections file for reproducibility (#121).
-        self.atl06sr_request_parms = {
-            "processing_levels": list(processing_levels),
-            "res": res,
-            "len": len,
-            "ats": ats,
-            "time_range": time_range,
-            "t0": t0_str,
-            "t1": t1_str,
-        }
-        self.atl06sr_parquet_paths = {}
+    def _load_cached_atl06sr(self, fn, parms):
+        """Return cached ATL06-SR points if a parquet matching ``parms`` exists.
 
-        for key, custom_parm in custom_parms.items():
-            parms = {**shared_parms, **custom_parm}
+        Returns the cached :class:`~geopandas.GeoDataFrame` when ``fn`` exists
+        and the SlideRule parameters it was built with match ``parms``; returns
+        ``None`` (signalling a fresh request is needed) otherwise.
+        """
+        if not os.path.exists(fn):
+            return None
+        print(f"Existing file found, reading in: {fn}")
+        atl06sr = gpd.read_parquet(fn)
+        if self._params_match_cache(parms, atl06sr):
+            return atl06sr
+        return None
 
-            fn_base = f"{filename}_{key}"
+    @staticmethod
+    def _params_match_cache(parms, atl06sr):
+        """Whether a cached parquet was produced by the same SlideRule params.
 
-            print(f"\nICESat-2 ATL06 request processing for: {key}")
-            fn = os.path.join(self.alt.directory, f"{fn_base}.parquet")
-            self.atl06sr_parquet_paths[key] = fn
+        The request parameters are persisted in the parquet's
+        ``sliderule_parameters`` column (see :meth:`_save_to_parquet`). The
+        ``poly`` is compared as a string and the ``output`` key (a random temp
+        path SlideRule injects during ``run()``) is stripped from both sides so
+        an otherwise-identical request is recognized as a cache hit. Prints the
+        reason and returns ``False`` when the cache cannot be reused.
+        """
+        if "sliderule_parameters" not in atl06sr.columns:
+            print("No parameters column found, regenerating...")
+            return False
+        try:
+            file_parms = json.loads(atl06sr["sliderule_parameters"].iloc[0])
+        except Exception as e:
+            print(f"Could not parse cached parameters: {e}. Regenerating...")
+            return False
 
-            print(parms)
+        parms_copy = parms.copy()
+        parms_copy["poly"] = str(parms_copy["poly"])
+        # Strip "output" (a random temp path injected by SlideRule during
+        # run()) from both sides before comparison.
+        parms_copy.pop("output", None)
+        file_parms.pop("output", None)
 
-            # Check for cached file with matching parameters
-            need_request = True
-            if os.path.exists(fn):
-                print(f"Existing file found, reading in: {fn}")
-                atl06sr = gpd.read_parquet(fn)
+        if str(parms_copy) == str(file_parms):
+            return True
+        print("Parameters don't match request. Regenerating...")
+        return False
 
-                if "sliderule_parameters" in atl06sr.columns:
-                    try:
-                        file_parms = json.loads(atl06sr["sliderule_parameters"].iloc[0])
-                        parms_copy = parms.copy()
-                        parms_copy["poly"] = str(parms_copy["poly"])
-                        # Strip "output" (contains a random temp path
-                        # injected by SlideRule during run()) from both
-                        # sides before comparison.
-                        parms_copy.pop("output", None)
-                        file_parms.pop("output", None)
+    def _request_atl06sr_level(self, parms, fn, save_to_parquet):
+        """Fetch one processing level from SlideRule and sample WorldCover.
 
-                        if str(parms_copy) == str(file_parms):
-                            need_request = False
-                        else:
-                            print("Parameters don't match request. Regenerating...")
-                    except Exception as e:
-                        print(
-                            f"Could not parse cached parameters: {e}. "
-                            "Regenerating..."
-                        )
-                else:
-                    print("No parameters column found, regenerating...")
-
-            if need_request:
-                atl06sr = sliderule_api.run("atl03x", parms)
-                # Sample ESA WorldCover before caching so the column
-                # is persisted in the parquet and doesn't have to be
-                # re-sampled on subsequent runs.
-                atl06sr = self._sample_worldcover_into_gdf(atl06sr)
-                if save_to_parquet:
-                    self._save_to_parquet(fn, atl06sr, parms)
-
-            self._ingest_atl06sr(key, atl06sr, h_sigma_quantile)
+        Runs the ``atl03x`` request, samples ESA WorldCover before caching so
+        the column is persisted in the parquet (and need not be re-sampled on
+        later runs), and optionally writes the parquet to ``fn``.
+        """
+        atl06sr = sliderule_api.run("atl03x", parms)
+        atl06sr = self._sample_worldcover_into_gdf(atl06sr)
+        if save_to_parquet:
+            self._save_to_parquet(fn, atl06sr, parms)
+        return atl06sr
 
     def _ingest_atl06sr(self, key, atl06sr, h_sigma_quantile=1.0):
         """

--- a/asp_plot/icesat2_source.py
+++ b/asp_plot/icesat2_source.py
@@ -970,13 +970,14 @@ class Icesat2Source(AltimetrySource):
         Interpolates DEM heights at ATL06-SR point locations and calculates
         the difference between ICESat-2 heights and DEM heights. If an aligned
         DEM is available, also calculates differences against it. Outliers
-        beyond ``n_sigma`` × NMAD from the median are removed by default.
+        beyond ``n_sigma`` × standard deviation from the mean are removed by
+        default (via :meth:`filter_outliers`).
 
         Parameters
         ----------
         n_sigma : float or None, optional
-            Remove dh outliers beyond this many NMAD from the median.
-            Default 3. Pass None to skip outlier filtering.
+            Remove dh outliers beyond this many standard deviations from the
+            mean. Default 3. Pass None to skip outlier filtering.
 
         Returns
         -------

--- a/asp_plot/icesat2_source.py
+++ b/asp_plot/icesat2_source.py
@@ -20,10 +20,9 @@ from datetime import datetime, timedelta, timezone
 import geopandas as gpd
 import numpy as np
 import pandas as pd
-import rioxarray
-import xarray as xr
 from sliderule import sliderule as sliderule_api
 
+from asp_plot.altimetry_source import AltimetrySource
 from asp_plot.stereopair_metadata_parser import StereopairMetadataParser
 from asp_plot.utils import Raster
 from asp_plot.utils import nmad as _nmad
@@ -33,7 +32,7 @@ logger = logging.getLogger(__name__)
 ICESAT2_MISSION_START = datetime(2018, 10, 14, tzinfo=timezone.utc)
 
 
-class Icesat2Source:
+class Icesat2Source(AltimetrySource):
     """Request, cache, filter and difference ICESat-2 ATL06-SR points.
 
     Parameters
@@ -55,7 +54,7 @@ class Icesat2Source:
         atl06sr_processing_levels=None,
         atl06sr_processing_levels_filtered=None,
     ):
-        self.alt = alt
+        super().__init__(alt)
         self.atl06sr_processing_levels = (
             {} if atl06sr_processing_levels is None else atl06sr_processing_levels
         )
@@ -776,14 +775,9 @@ class Icesat2Source:
         for key, atl06sr in self.atl06sr_processing_levels_filtered.items():
             if column not in atl06sr.columns:
                 continue
-            dh = atl06sr[column]
-            mean_val = np.nanmean(dh)
-            std_val = np.nanstd(dh.dropna().values)
-            if std_val == 0 or np.isnan(std_val):
+            mask = self._std_outlier_mask(atl06sr[column], n_sigma)
+            if mask is None:
                 continue
-            mask = (dh - mean_val).abs() <= n_sigma * std_val
-            # Keep rows where column is NaN (no dh yet) so they aren't dropped
-            mask = mask | dh.isna()
             n_before = len(atl06sr)
             self.atl06sr_processing_levels_filtered[key] = atl06sr[mask]
             n_after = len(self.atl06sr_processing_levels_filtered[key])
@@ -962,14 +956,12 @@ class Icesat2Source:
         CSV format with columns for longitude, latitude, and height.
         """
         atl06sr = self.atl06sr_processing_levels_filtered[key].to_crs("EPSG:4326")
-        csv_fn = os.path.join(self.alt.directory, f"{filename_prefix}_{key}.csv")
         df = atl06sr[["geometry", "h_mean"]].copy()
         df["lon"] = df["geometry"].x
         df["lat"] = df["geometry"].y
         df["height_above_datum"] = df["h_mean"]
         df = df[["lon", "lat", "height_above_datum"]]
-        df.to_csv(csv_fn, header=True, index=False)
-        return csv_fn
+        return self._write_csv_to_directory(df, f"{filename_prefix}_{key}.csv")
 
     def atl06sr_to_dem_dh(self, n_sigma=3):
         """
@@ -1001,32 +993,22 @@ class Icesat2Source:
         ATL06-SR point locations using xarray and rioxarray. It handles
         coordinate system conversions automatically.
         """
-        dem = rioxarray.open_rasterio(self.alt.dem_fn, masked=True).squeeze()
-        epsg = dem.rio.crs.to_epsg()
+        # Sampling reprojects each track to the DEM CRS and stores the
+        # reprojected frame back, so downstream track geometry (segment
+        # endpoints) lives in the DEM/working CRS. The DEM is opened once and
+        # interpolated per key.
+        dem = self._open_dem(self.alt.dem_fn)
         for key, atl06sr in self.atl06sr_processing_levels_filtered.items():
-            atl06sr = atl06sr.to_crs(f"EPSG:{epsg}")
-
-            x = xr.DataArray(atl06sr.geometry.x.values, dims="z")
-            y = xr.DataArray(atl06sr.geometry.y.values, dims="z")
-            sample = dem.interp(x=x, y=y)
-
-            atl06sr["dem_height"] = sample.values
+            sample, atl06sr = self._interp_dem_at_points(dem, atl06sr)
+            atl06sr["dem_height"] = sample
             atl06sr["icesat_minus_dem"] = atl06sr["h_mean"] - atl06sr["dem_height"]
             self.atl06sr_processing_levels_filtered[key] = atl06sr
 
         if self.alt.aligned_dem_fn:
-            aligned_dem = rioxarray.open_rasterio(
-                self.alt.aligned_dem_fn, masked=True
-            ).squeeze()
-            epsg = aligned_dem.rio.crs.to_epsg()
+            aligned_dem = self._open_dem(self.alt.aligned_dem_fn)
             for key, atl06sr in self.atl06sr_processing_levels_filtered.items():
-                atl06sr = atl06sr.to_crs(f"EPSG:{epsg}")
-
-                x = xr.DataArray(atl06sr.geometry.x.values, dims="z")
-                y = xr.DataArray(atl06sr.geometry.y.values, dims="z")
-                sample = aligned_dem.interp(x=x, y=y)
-
-                atl06sr["aligned_dem_height"] = sample.values
+                sample, atl06sr = self._interp_dem_at_points(aligned_dem, atl06sr)
+                atl06sr["aligned_dem_height"] = sample
                 atl06sr["icesat_minus_aligned_dem"] = (
                     atl06sr["h_mean"] - atl06sr["aligned_dem_height"]
                 )

--- a/asp_plot/planetary_source.py
+++ b/asp_plot/planetary_source.py
@@ -10,14 +10,11 @@ coordinating :class:`Altimetry` instance passed at construction.
 """
 
 import logging
-import os
 
 import geopandas as gpd
-import numpy as np
 import pandas as pd
-import rioxarray
-import xarray as xr
 
+from asp_plot.altimetry_source import AltimetrySource
 from asp_plot.bodies import BODIES
 
 logger = logging.getLogger(__name__)
@@ -96,8 +93,16 @@ def gds_query_async(query_type, bounds, results_code, email=None, **extra_params
     return jobid_elem.text.strip()
 
 
-class PlanetarySource:
-    """Load and analyze LOLA (Moon) / MOLA (Mars) altimetry against an ASP DEM.
+class PlanetarySource(AltimetrySource):
+    """Body-agnostic planetary altimetry against an ASP DEM.
+
+    Holds the machinery shared by every planetary instrument: sampling the DEM
+    at the loaded points, differencing, outlier filtering, and exporting a
+    pc_align-ready CSV. The CSV *loader* is body-specific and lives in the
+    :class:`LolaSource` (Moon) and :class:`MolaSource` (Mars) subclasses; the
+    coordinator instantiates the right one from the DEM's body. The base
+    :meth:`load_planetary_csv` raises, so an Earth DEM that reaches here is
+    pointed back at ICESat-2.
 
     Parameters
     ----------
@@ -107,6 +112,9 @@ class PlanetarySource:
         are read from it so a single source of truth describes the DEM
         under analysis.
     """
+
+    #: Reference altimetry instrument name, set by the body subclasses.
+    instrument = None
 
     # Column name candidates for LOLA and MOLA CSVs
     _LON_CANDIDATES = [
@@ -128,44 +136,43 @@ class PlanetarySource:
         "radius",
     ]
 
-    # Geographic CRS WKT strings for building GeoDataFrames (sourced from the
-    # body registry).
-    _MOON_GEO_CRS = BODIES["moon"].geographic_crs_wkt
-    _MARS_GEO_CRS = BODIES["mars"].geographic_crs_wkt
-
     def __init__(self, alt):
-        self.alt = alt
+        super().__init__(alt)
         self.planetary_points = None
 
     def load_planetary_csv(self, csv_path):
-        """Load LOLA or MOLA altimetry data from a GDS topo CSV file.
+        """Load a planetary altimetry CSV (overridden per body).
 
-        The CSV is obtained via the ``request_planetary_altimetry`` CLI
-        tool, which submits an async query to the ODE GDS API and emails
-        the user a download link.  The user downloads and unzips the
-        result, then passes the ``*_topo_csv.csv`` file here.
-
-        Automatically selects the LOLA or MOLA parser based on the DEM's
-        planetary body.
+        The base implementation raises: only :class:`LolaSource` and
+        :class:`MolaSource` know how to parse a GDS CSV. The CSV is obtained
+        via the ``request_planetary_altimetry`` CLI tool, which submits an
+        async query to the ODE GDS API and emails the user a download link;
+        the user downloads and unzips the result, then passes the
+        ``*_topo_csv.csv`` / ``*_pts_csv.csv`` file to the body source.
 
         Parameters
         ----------
         csv_path : str
-            Path to a ``*_topo_csv.csv`` file from the ODE GDS.
+            Path to a CSV file from the ODE GDS.
         """
-        from asp_plot.utils import detect_planetary_body
+        raise ValueError(
+            "Planetary altimetry CSV loading is not supported for this DEM "
+            "(no LOLA/MOLA body detected). Use ICESat-2 for Earth DEMs."
+        )
 
-        body = detect_planetary_body(self.alt.dem_fn)
+    def _build_planetary_gdf(self, df, geo_crs):
+        """Build and store the planetary GeoDataFrame from a parsed CSV frame.
 
-        if body == "moon":
-            self._load_lola_csv(csv_path)
-        elif body == "mars":
-            self._load_mola_csv(csv_path)
-        else:
-            raise ValueError(
-                f"Planetary altimetry CSV loading is not supported for "
-                f"body={body}. Use ICESat-2 for Earth DEMs."
-            )
+        ``df`` must carry ``lon`` / ``lat`` / ``height`` / ``radius_m`` columns.
+        Stores the result on ``self.planetary_points`` and returns it.
+        """
+        gdf = gpd.GeoDataFrame(
+            df,
+            geometry=gpd.points_from_xy(df["lon"], df["lat"]),
+            crs=geo_crs,
+        )
+        self.planetary_points = gdf
+        return gdf
 
     @staticmethod
     def _find_csv_column(cols_lower, candidates):
@@ -252,103 +259,6 @@ class PlanetarySource:
 
         return df, is_radius
 
-    def _load_lola_csv(self, csv_path):
-        """Parse a LOLA topo CSV into a GeoDataFrame.
-
-        Stores height above the IAU 1737.4 km lunar sphere on
-        ``self.planetary_points["height"]`` and the planetary radius on
-        ``self.planetary_points["radius_m"]`` (used by pc_align).
-
-        The Moon is nearly spherical (1.4 km equatorial-vs-polar variation),
-        so LOLA TOPOGRAPHY ≈ Pt_Radius − 1737.4 km. Either column gives the
-        same dh against an ASP lunar DEM to <1 m.
-
-        Parameters
-        ----------
-        csv_path : str
-            Path to a LOLA RDR CSV from the ODE GDS API.
-        """
-        df, is_radius = self._load_planetary_csv_common(
-            csv_path, "LOLA", prefer="radius"
-        )
-
-        if is_radius:
-            # LOLA RDR Pt_Radius is in KILOMETERS (per the ODE GDS Point
-            # per Row CSV header), unlike MOLA PEDR PLANET_RAD which is
-            # in meters. Detect units by magnitude (~1737 vs ~1737000)
-            # and normalize to meters.
-            if df["height_raw"].median() < 10000:
-                df["height_raw"] = df["height_raw"] * 1000.0
-                unit_note = " (km → m)"
-            else:
-                unit_note = ""
-            df["height"] = df["height_raw"] - MOON_IAU_SPHERE_RADIUS
-            df["radius_m"] = df["height_raw"]
-            source = f"Pt_Radius{unit_note}"
-        else:
-            # Topography path: the Moon is essentially spherical so LOLA
-            # topography ≈ height above the IAU 1737.4 km sphere.
-            df["height"] = df["height_raw"]
-            df["radius_m"] = df["height_raw"] + MOON_IAU_SPHERE_RADIUS
-            source = "Topography"
-
-        gdf = gpd.GeoDataFrame(
-            df,
-            geometry=gpd.points_from_xy(df["lon"], df["lat"]),
-            crs=self._MOON_GEO_CRS,
-        )
-        self.planetary_points = gdf
-        print(f"Loaded {len(gdf)} LOLA points (using {source} column)")
-
-    def _load_mola_csv(self, csv_path):
-        """Parse a MOLA PEDR CSV into a GeoDataFrame.
-
-        Uses the PLANET_RAD column and converts to height above the IAU
-        Mars sphere (3,396,190 m): ``height = PLANET_RAD - 3,396,190``.
-        This is the same reference as ASP DEMs, so dh = MOLA − DEM is
-        directly meaningful at all latitudes.
-
-        TOPOGRAPHY (in ``*_topo_csv.csv``) is referenced to the MOLA
-        oblate areoid and produces a latitude-dependent offset of up to
-        ~10 km against an ASP DEM, so it is rejected here. Pass the
-        ``*_pts_csv.csv`` from the ODE GDS download instead.
-
-        Parameters
-        ----------
-        csv_path : str
-            Path to a MOLA PEDR CSV from the ODE GDS API. Must include
-            a ``PLANET_RAD`` column (use the ``*_pts_csv.csv`` file).
-        """
-        df, is_radius = self._load_planetary_csv_common(
-            csv_path, "MOLA", prefer="radius"
-        )
-
-        if not is_radius:
-            raise ValueError(
-                f"MOLA CSV is missing the PLANET_RAD column: {csv_path}\n"
-                "The ODE GDS '*_topo_csv.csv' only has TOPOGRAPHY, which is "
-                "height above the oblate MOLA areoid. ASP DEMs use the "
-                "spherical IAU 2000 datum (3,396,190 m), so dh from "
-                "TOPOGRAPHY carries a latitude-dependent offset of up to "
-                "~10 km that pc_align cannot remove.\n\n"
-                "Pass the '*_pts_csv.csv' file from the same ODE GDS "
-                "download instead — it contains PLANET_RAD."
-            )
-
-        df["height"] = df["height_raw"] - MARS_IAU_SPHERE_RADIUS
-        df["radius_m"] = df["height_raw"]
-
-        gdf = gpd.GeoDataFrame(
-            df,
-            geometry=gpd.points_from_xy(df["lon"], df["lat"]),
-            crs=self._MARS_GEO_CRS,
-        )
-        self.planetary_points = gdf
-        print(
-            f"Loaded {len(gdf)} MOLA points "
-            f"(PLANET_RAD - {MARS_IAU_SPHERE_RADIUS:.0f} m → height above IAU sphere)"
-        )
-
     def _sample_dem_at_planetary_points(self, dem_fn, height_col, dh_col):
         """Interpolate DEM heights at the loaded altimetry points.
 
@@ -359,13 +269,8 @@ class PlanetarySource:
         if self.planetary_points is None or self.planetary_points.empty:
             return
 
-        dem = rioxarray.open_rasterio(dem_fn, masked=True).squeeze()
-        dem_crs = dem.rio.crs
-
-        pts = self.planetary_points.to_crs(dem_crs)
-        x = xr.DataArray(pts.geometry.x.values, dims="z")
-        y = xr.DataArray(pts.geometry.y.values, dims="z")
-        sample = dem.interp(x=x, y=y).values
+        dem = self._open_dem(dem_fn)
+        sample, _ = self._interp_dem_at_points(dem, self.planetary_points)
 
         self.planetary_points[height_col] = sample
         self.planetary_points[dh_col] = self.planetary_points["height"] - sample
@@ -407,13 +312,10 @@ class PlanetarySource:
         print(f"Computed dh for {len(valid)} of {len(self.planetary_points)} points")
 
         if n_sigma is not None and not valid.empty:
-            mean_val = np.nanmean(valid.values)
-            std_val = np.nanstd(valid.values)
-            if std_val > 0 and not np.isnan(std_val):
-                dh = self.planetary_points["altimetry_minus_dem"]
-                mask = (dh - mean_val).abs() <= n_sigma * std_val
-                # Keep rows where dh is NaN
-                mask = mask | dh.isna()
+            mask = self._std_outlier_mask(
+                self.planetary_points["altimetry_minus_dem"], n_sigma
+            )
+            if mask is not None:
                 n_before = len(self.planetary_points)
                 self.planetary_points = self.planetary_points[mask]
                 n_after = len(self.planetary_points)
@@ -461,6 +363,105 @@ class PlanetarySource:
         if df.empty:
             raise ValueError("No valid planetary altimetry points after dropping NaNs.")
 
-        csv_fn = os.path.join(self.alt.directory, f"{filename_prefix}.csv")
-        df.to_csv(csv_fn, header=True, index=False)
-        return csv_fn
+        return self._write_csv_to_directory(df, f"{filename_prefix}.csv")
+
+
+class LolaSource(PlanetarySource):
+    """LOLA (Moon) altimetry source.
+
+    Parses a LOLA RDR CSV from the ODE GDS into height above the IAU 1737.4 km
+    lunar sphere. The Moon is nearly spherical (1.4 km equatorial-vs-polar
+    variation), so LOLA TOPOGRAPHY ≈ Pt_Radius − 1737.4 km — either column
+    gives the same dh against an ASP lunar DEM to <1 m.
+    """
+
+    instrument = "LOLA"
+
+    def load_planetary_csv(self, csv_path):
+        """Parse a LOLA topo/RDR CSV into ``self.planetary_points``.
+
+        Stores height above the IAU lunar sphere on ``height`` and the
+        planetary radius on ``radius_m`` (used by pc_align).
+
+        Parameters
+        ----------
+        csv_path : str
+            Path to a LOLA RDR CSV from the ODE GDS API.
+        """
+        df, is_radius = self._load_planetary_csv_common(
+            csv_path, "LOLA", prefer="radius"
+        )
+
+        if is_radius:
+            # LOLA RDR Pt_Radius is in KILOMETERS (per the ODE GDS Point
+            # per Row CSV header), unlike MOLA PEDR PLANET_RAD which is
+            # in meters. Detect units by magnitude (~1737 vs ~1737000)
+            # and normalize to meters.
+            if df["height_raw"].median() < 10000:
+                df["height_raw"] = df["height_raw"] * 1000.0
+                unit_note = " (km → m)"
+            else:
+                unit_note = ""
+            df["height"] = df["height_raw"] - MOON_IAU_SPHERE_RADIUS
+            df["radius_m"] = df["height_raw"]
+            source = f"Pt_Radius{unit_note}"
+        else:
+            # Topography path: the Moon is essentially spherical so LOLA
+            # topography ≈ height above the IAU 1737.4 km sphere.
+            df["height"] = df["height_raw"]
+            df["radius_m"] = df["height_raw"] + MOON_IAU_SPHERE_RADIUS
+            source = "Topography"
+
+        gdf = self._build_planetary_gdf(df, BODIES["moon"].geographic_crs_wkt)
+        print(f"Loaded {len(gdf)} LOLA points (using {source} column)")
+
+
+class MolaSource(PlanetarySource):
+    """MOLA (Mars) altimetry source.
+
+    Parses a MOLA PEDR CSV from the ODE GDS, using the PLANET_RAD column to
+    compute height above the IAU Mars sphere (3,396,190 m):
+    ``height = PLANET_RAD - 3,396,190``. This is the same reference as ASP
+    DEMs, so dh = MOLA − DEM is directly meaningful at all latitudes.
+    """
+
+    instrument = "MOLA"
+
+    def load_planetary_csv(self, csv_path):
+        """Parse a MOLA PEDR CSV into ``self.planetary_points``.
+
+        TOPOGRAPHY (in ``*_topo_csv.csv``) is referenced to the MOLA oblate
+        areoid and produces a latitude-dependent offset of up to ~10 km against
+        an ASP DEM, so it is rejected here. Pass the ``*_pts_csv.csv`` from the
+        ODE GDS download instead — it carries PLANET_RAD.
+
+        Parameters
+        ----------
+        csv_path : str
+            Path to a MOLA PEDR CSV from the ODE GDS API. Must include
+            a ``PLANET_RAD`` column (use the ``*_pts_csv.csv`` file).
+        """
+        df, is_radius = self._load_planetary_csv_common(
+            csv_path, "MOLA", prefer="radius"
+        )
+
+        if not is_radius:
+            raise ValueError(
+                f"MOLA CSV is missing the PLANET_RAD column: {csv_path}\n"
+                "The ODE GDS '*_topo_csv.csv' only has TOPOGRAPHY, which is "
+                "height above the oblate MOLA areoid. ASP DEMs use the "
+                "spherical IAU 2000 datum (3,396,190 m), so dh from "
+                "TOPOGRAPHY carries a latitude-dependent offset of up to "
+                "~10 km that pc_align cannot remove.\n\n"
+                "Pass the '*_pts_csv.csv' file from the same ODE GDS "
+                "download instead — it contains PLANET_RAD."
+            )
+
+        df["height"] = df["height_raw"] - MARS_IAU_SPHERE_RADIUS
+        df["radius_m"] = df["height_raw"]
+
+        gdf = self._build_planetary_gdf(df, BODIES["mars"].geographic_crs_wkt)
+        print(
+            f"Loaded {len(gdf)} MOLA points "
+            f"(PLANET_RAD - {MARS_IAU_SPHERE_RADIUS:.0f} m → height above IAU sphere)"
+        )

--- a/asp_plot/planetary_source.py
+++ b/asp_plot/planetary_source.py
@@ -1,12 +1,15 @@
-"""Planetary (LOLA/MOLA) altimetry source.
+"""Planetary (LOLA/MOLA) altimetry sources.
 
 Owns the planetary-altimetry side of :class:`asp_plot.altimetry.Altimetry`:
 loading LOLA (Moon) and MOLA (Mars) point clouds from ODE GDS CSV exports,
 sampling the ASP DEM at those points, and exporting a pc_align-ready CSV.
 
-The class holds its own data (``planetary_points``) and reads the
-cross-cutting ``dem_fn`` / ``directory`` / ``aligned_dem_fn`` from the
-coordinating :class:`Altimetry` instance passed at construction.
+The body-agnostic machinery (DEM differencing, pc_align export, the shared CSV
+reader) lives on :class:`PlanetarySource`; the per-body CSV loaders live on its
+:class:`LolaSource` (Moon) and :class:`MolaSource` (Mars) subclasses. Each
+instance holds its own data (``planetary_points``) and reads the cross-cutting
+``dem_fn`` / ``directory`` / ``aligned_dem_fn`` from the coordinating
+:class:`Altimetry` instance passed at construction.
 """
 
 import logging
@@ -389,7 +392,7 @@ class LolaSource(PlanetarySource):
             Path to a LOLA RDR CSV from the ODE GDS API.
         """
         df, is_radius = self._load_planetary_csv_common(
-            csv_path, "LOLA", prefer="radius"
+            csv_path, self.instrument, prefer="radius"
         )
 
         if is_radius:
@@ -442,7 +445,7 @@ class MolaSource(PlanetarySource):
             a ``PLANET_RAD`` column (use the ``*_pts_csv.csv`` file).
         """
         df, is_radius = self._load_planetary_csv_common(
-            csv_path, "MOLA", prefer="radius"
+            csv_path, self.instrument, prefer="radius"
         )
 
         if not is_radius:

--- a/tests/test_altimetry.py
+++ b/tests/test_altimetry.py
@@ -11,7 +11,7 @@ from shapely.geometry import Point
 from asp_plot.altimetry import ICESAT2_MISSION_START, AlignmentResult, Altimetry
 from asp_plot.altimetry_plots import AltimetryPlotter
 from asp_plot.icesat2_source import Icesat2Source
-from asp_plot.planetary_source import PlanetarySource
+from asp_plot.planetary_source import LolaSource, MolaSource, PlanetarySource
 
 matplotlib.use("Agg")
 
@@ -695,6 +695,31 @@ class TestPlanetaryDh:
         )
 
 
+class TestPlanetarySourceDispatch:
+    """The coordinator picks the planetary source from the DEM's body."""
+
+    DEM_FN = "tests/test_data/stereo/date_time_left_right_1m-DEM.tif"
+
+    @pytest.mark.parametrize(
+        "body, cls",
+        [("moon", LolaSource), ("mars", MolaSource), ("earth", PlanetarySource)],
+    )
+    def test_coordinator_picks_body_source(self, monkeypatch, body, cls):
+        import asp_plot.altimetry as altmod
+
+        monkeypatch.setattr(altmod, "detect_planetary_body", lambda fn: body)
+        alt = Altimetry(directory="tests/test_data", dem_fn=self.DEM_FN)
+        assert type(alt.planetary) is cls
+
+    def test_earth_base_source_load_raises(self):
+        # The Earth (base) source cannot parse a planetary CSV and redirects
+        # the caller to ICESat-2.
+        alt = Altimetry(directory="tests/test_data", dem_fn=self.DEM_FN)
+        assert isinstance(alt.planetary, PlanetarySource)
+        with pytest.raises(ValueError, match="ICESat-2"):
+            alt.planetary.load_planetary_csv("anything.csv")
+
+
 class TestLoadPlanetaryCsv:
     """Test LOLA and MOLA CSV loading and validation."""
 
@@ -714,15 +739,16 @@ class TestLoadPlanetaryCsv:
             " 15.3286,  -9.6021,     297.16\n"
             " 15.3286,  -9.6039,     300.09\n"
         )
-        alt.planetary._load_lola_csv(str(csv))
-        assert alt.planetary_points is not None
-        assert len(alt.planetary_points) == 3
-        assert "height" in alt.planetary_points.columns
-        assert "radius_m" in alt.planetary_points.columns
+        src = LolaSource(alt)
+        src.load_planetary_csv(str(csv))
+        assert src.planetary_points is not None
+        assert len(src.planetary_points) == 3
+        assert "height" in src.planetary_points.columns
+        assert "radius_m" in src.planetary_points.columns
         # Height should equal topography directly for LOLA
-        assert alt.planetary_points["height"].iloc[0] == pytest.approx(295.81)
+        assert src.planetary_points["height"].iloc[0] == pytest.approx(295.81)
         # radius_m back-computed against the IAU 1737.4 km sphere
-        assert alt.planetary_points["radius_m"].iloc[0] == pytest.approx(1737695.81)
+        assert src.planetary_points["radius_m"].iloc[0] == pytest.approx(1737695.81)
 
     def test_load_lola_csv_pts_radius_km(self, alt, tmp_path):
         """LOLA Point per Row CSV has Pt_Radius in km — auto-convert to m."""
@@ -732,12 +758,13 @@ class TestLoadPlanetaryCsv:
             " 15.3287,  -9.6003, 1737.668720\n"
             " 15.3286,  -9.6021, 1737.666748\n"
         )
-        alt.planetary._load_lola_csv(str(csv))
+        src = LolaSource(alt)
+        src.load_planetary_csv(str(csv))
         # Pt_Radius is preferred; km auto-detected and converted to m.
-        assert alt.planetary_points["radius_m"].iloc[0] == pytest.approx(
+        assert src.planetary_points["radius_m"].iloc[0] == pytest.approx(
             1737668.720, abs=1e-3
         )
-        assert alt.planetary_points["height"].iloc[0] == pytest.approx(
+        assert src.planetary_points["height"].iloc[0] == pytest.approx(
             268.720, abs=1e-3
         )
 
@@ -749,14 +776,15 @@ class TestLoadPlanetaryCsv:
             "137.13264, -4.91750,   -4499.73, 3391690.27,1999-08-31T19:13:24.847\n"
             "137.13197, -4.91240,   -4505.07, 3391684.93,1999-08-31T19:13:24.947\n"
         )
-        alt.planetary._load_mola_csv(str(csv))
-        assert alt.planetary_points is not None
-        assert len(alt.planetary_points) == 2
-        assert "height" in alt.planetary_points.columns
-        assert "radius_m" in alt.planetary_points.columns
+        src = MolaSource(alt)
+        src.load_planetary_csv(str(csv))
+        assert src.planetary_points is not None
+        assert len(src.planetary_points) == 2
+        assert "height" in src.planetary_points.columns
+        assert "radius_m" in src.planetary_points.columns
         # height = PLANET_RAD - 3,396,190 (IAU sphere)
-        assert alt.planetary_points["height"].iloc[0] == pytest.approx(-4499.73)
-        assert alt.planetary_points["radius_m"].iloc[0] == pytest.approx(3391690.27)
+        assert src.planetary_points["height"].iloc[0] == pytest.approx(-4499.73)
+        assert src.planetary_points["radius_m"].iloc[0] == pytest.approx(3391690.27)
 
     def test_load_mola_topo_only_raises(self, alt, tmp_path):
         """Test that a *_topo_csv.csv (no PLANET_RAD) is rejected with help."""
@@ -766,7 +794,7 @@ class TestLoadPlanetaryCsv:
             "137.13264, -4.91750,   -4499.73,1999-08-31T19:13:24.847\n"
         )
         with pytest.raises(ValueError, match="PLANET_RAD"):
-            alt.planetary._load_mola_csv(str(csv))
+            MolaSource(alt).load_planetary_csv(str(csv))
 
     def test_load_mola_csv_lon_conversion(self, alt, tmp_path):
         """Test that MOLA 0-360 longitude is converted to -180/180."""
@@ -775,22 +803,23 @@ class TestLoadPlanetaryCsv:
             "LONG_EAST,LAT_NORTH, TOPOGRAPHY, PLANET_RAD,            UTC\n"
             "270.0, 10.0, -3000.0, 3393190.0, 1999-01-01T00:00:00\n"
         )
-        alt.planetary._load_mola_csv(str(csv))
-        assert alt.planetary_points["lon"].iloc[0] == pytest.approx(-90.0)
+        src = MolaSource(alt)
+        src.load_planetary_csv(str(csv))
+        assert src.planetary_points["lon"].iloc[0] == pytest.approx(-90.0)
 
     def test_load_csv_empty_raises(self, alt, tmp_path):
         """Test that empty CSV raises ValueError."""
         csv = tmp_path / "empty.csv"
         csv.write_text("Pt_Longitude, Pt_Latitude, Topography\n")
         with pytest.raises(ValueError, match="empty"):
-            alt.planetary._load_lola_csv(str(csv))
+            LolaSource(alt).load_planetary_csv(str(csv))
 
     def test_load_csv_wrong_columns_raises(self, alt, tmp_path):
         """Test that wrong columns raise ValueError with helpful message."""
         csv = tmp_path / "wrong.csv"
         csv.write_text("col_a, col_b, col_c\n1,2,3\n")
         with pytest.raises(ValueError, match="planetary radius"):
-            alt.planetary._load_lola_csv(str(csv))
+            LolaSource(alt).load_planetary_csv(str(csv))
 
     def test_load_planetary_csv_earth_raises(self, alt, tmp_path):
         """Test that load_planetary_csv rejects Earth DEMs."""

--- a/tests/test_altimetry_source.py
+++ b/tests/test_altimetry_source.py
@@ -1,0 +1,65 @@
+"""Tests for the shared AltimetrySource base machinery.
+
+The DEM-sampling, std-outlier-mask and CSV-writer helpers were lifted out of
+the ICESat-2 and planetary sources (#140); these exercise them directly.
+"""
+
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+from shapely.geometry import Point
+
+from asp_plot.altimetry_source import AltimetrySource
+from asp_plot.utils import Raster
+
+DEM_FN = "tests/test_data/stereo/date_time_left_right_1m-DEM.tif"
+
+
+class TestStdOutlierMask:
+    def test_keeps_within_sigma_drops_outlier_keeps_nan(self):
+        dh = pd.Series([0.0, 0.1, -0.1, 0.05, 100.0, np.nan])
+        mask = AltimetrySource._std_outlier_mask(dh, n_sigma=1)
+        assert mask is not None
+        assert mask.iloc[0]  # central value kept
+        assert not mask.iloc[4]  # extreme outlier dropped
+        assert mask.iloc[5]  # NaN row kept (no dh yet)
+
+    def test_degenerate_std_returns_none(self):
+        # Zero spread → no meaningful threshold → signal "do not filter".
+        assert AltimetrySource._std_outlier_mask(pd.Series([5.0, 5.0, 5.0]), 3) is None
+
+    def test_all_nan_returns_none(self):
+        assert AltimetrySource._std_outlier_mask(pd.Series([np.nan, np.nan]), 3) is None
+
+
+class TestInterpDemAtPoints:
+    def test_returns_values_and_reprojected_points(self):
+        raster = Raster(DEM_FN)
+        lon_min, lat_min, lon_max, lat_max = raster.get_bounds(
+            latlon=True, json_format=False
+        )
+        pts = gpd.GeoDataFrame(
+            geometry=[Point((lon_min + lon_max) / 2, (lat_min + lat_max) / 2)],
+            crs="EPSG:4326",
+        )
+        dem = AltimetrySource._open_dem(DEM_FN)
+        sampled, reproj = AltimetrySource._interp_dem_at_points(dem, pts)
+        assert len(sampled) == 1
+        # Points come back in the DEM CRS (the working CRS downstream code uses).
+        assert reproj.crs == dem.rio.crs
+        # A point at the DEM centre should sample a finite elevation.
+        assert np.isfinite(sampled[0])
+
+
+class TestWriteCsvToDirectory:
+    def test_writes_under_coordinator_directory(self, tmp_path):
+        class FakeAlt:
+            directory = str(tmp_path)
+
+        src = AltimetrySource(FakeAlt())
+        df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+        path = src._write_csv_to_directory(df, "out.csv")
+        assert path == str(tmp_path / "out.csv")
+        back = pd.read_csv(path)
+        assert list(back.columns) == ["a", "b"]
+        assert len(back) == 2

--- a/tests/test_icesat2_source.py
+++ b/tests/test_icesat2_source.py
@@ -1,0 +1,172 @@
+"""Tests for the decomposed ICESat-2 ATL06-SR request path.
+
+``request_atl06sr_multi_processing`` is network-bound (it calls SlideRule), so
+before #140 its cache-parameter-comparison logic was never exercised in CI.
+These tests mock the SlideRule request with a small synthetic ATL06-SR
+GeoDataFrame so the decomposed helpers — ``_build_level_parms``,
+``_params_match_cache``, ``_load_cached_atl06sr`` and ``_request_atl06sr_level``
+— and the parquet cache round-trip are covered without a network call.
+"""
+
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+import pytest
+from shapely.geometry import Point
+
+from asp_plot.altimetry import Altimetry
+from asp_plot.icesat2_source import Icesat2Source
+
+DEM_FN = "tests/test_data/stereo/date_time_left_right_1m-DEM.tif"
+REGION = [-149.90, 70.00, -149.80, 70.10]
+
+
+def _synthetic_atl06sr(n=6):
+    """A minimal ATL06-SR-like GeoDataFrame the ingest path accepts.
+
+    Carries the columns ``_ingest_atl06sr`` reads (``cycle``, ``h_sigma``) plus
+    a tz-naive DatetimeIndex named ``time``, mimicking a SlideRule result.
+    """
+    times = pd.date_range("2022-04-01", periods=n, freq="D")
+    lons = np.linspace(REGION[0], REGION[2], n)
+    lats = np.linspace(REGION[1], REGION[3], n)
+    gdf = gpd.GeoDataFrame(
+        {
+            "cycle": np.full(n, 5),
+            "h_sigma": np.linspace(0.1, 0.5, n),
+            "h_mean": np.linspace(100.0, 110.0, n),
+            "rgt": np.full(n, 1),
+            "spot": np.full(n, 1),
+            "x_atc": np.linspace(0.0, 1000.0, n),
+        },
+        geometry=[Point(x, y) for x, y in zip(lons, lats)],
+        crs="EPSG:4326",
+    )
+    gdf.index = pd.DatetimeIndex(times, name="time")
+    return gdf
+
+
+@pytest.fixture
+def src(tmp_path):
+    """An Icesat2Source whose coordinator writes into a temp directory."""
+    alt = Altimetry(directory=str(tmp_path), dem_fn=DEM_FN)
+    # Avoid the real SlideRule session init and WorldCover S3 sampling.
+    alt.icesat2._sliderule_initialized = True
+    alt.icesat2._sample_worldcover_into_gdf = lambda df: df
+    return alt.icesat2
+
+
+class TestBuildLevelParms:
+    def test_only_requested_levels_returned(self):
+        parms = Icesat2Source._build_level_parms(
+            ["all", "ground"], REGION, "t0", "t1", 20, 40, 20, 6, 10
+        )
+        assert set(parms.keys()) == {"all", "ground"}
+
+    def test_shared_and_custom_merged(self):
+        parms = Icesat2Source._build_level_parms(
+            ["all"], REGION, "t0", "t1", 20, 40, 20, 6, 10
+        )["all"]
+        # Shared envelope
+        assert parms["poly"] == REGION
+        assert parms["t0"] == "t0" and parms["t1"] == "t1"
+        assert parms["res"] == 20 and parms["len"] == 40 and parms["ats"] == 20
+        assert parms["fit"] == {"maxi": 6}
+        # Level-specific
+        assert parms["cnf"] == "atl03_high"
+        assert parms["srt"] == -1
+        assert parms["cnt"] == 10
+
+    def test_ground_uses_reduced_count_and_class(self):
+        parms = Icesat2Source._build_level_parms(
+            ["ground"], REGION, "t0", "t1", 20, 40, 20, 6, 10
+        )["ground"]
+        assert parms["cnt"] == 5
+        assert parms["atl08_class"] == "atl08_ground"
+
+
+class TestParamsMatchCache:
+    def test_matches_after_round_trip(self, src, tmp_path):
+        parms = Icesat2Source._build_level_parms(
+            ["all"], REGION, "t0", "t1", 20, 40, 20, 6, 10
+        )["all"]
+        fn = str(tmp_path / "atl06sr_all.parquet")
+        src._save_to_parquet(fn, _synthetic_atl06sr(), parms)
+        cached = gpd.read_parquet(fn)
+        assert src._params_match_cache(parms, cached) is True
+
+    def test_mismatch_when_param_differs(self, src, tmp_path):
+        saved = Icesat2Source._build_level_parms(
+            ["all"], REGION, "t0", "t1", 20, 40, 20, 6, 10
+        )["all"]
+        fn = str(tmp_path / "atl06sr_all.parquet")
+        src._save_to_parquet(fn, _synthetic_atl06sr(), saved)
+        cached = gpd.read_parquet(fn)
+        # Different resolution → should not be recognized as a cache hit.
+        other = Icesat2Source._build_level_parms(
+            ["all"], REGION, "t0", "t1", 30, 40, 20, 6, 10
+        )["all"]
+        assert src._params_match_cache(other, cached) is False
+
+    def test_no_parameters_column(self, src):
+        assert src._params_match_cache({"res": 20}, _synthetic_atl06sr()) is False
+
+
+class TestRequestAtl06srMultiProcessing:
+    """End-to-end through the orchestrator with SlideRule mocked."""
+
+    def _patch_run(self, monkeypatch):
+        calls = {"n": 0}
+
+        def fake_run(api, parms):
+            calls["n"] += 1
+            return _synthetic_atl06sr()
+
+        monkeypatch.setattr("asp_plot.icesat2_source.sliderule_api.run", fake_run)
+        return calls
+
+    def test_fresh_request_then_cache_hit(self, src, monkeypatch):
+        calls = self._patch_run(monkeypatch)
+
+        src.request_atl06sr_multi_processing(
+            processing_levels=["all"],
+            region=REGION,
+            save_to_parquet=True,
+            filename="atl06sr",
+        )
+        assert calls["n"] == 1
+        assert "all" in src.atl06sr_processing_levels
+        assert "all" in src.atl06sr_processing_levels_filtered
+        # cycle >= 3 retained, h_sigma != 0 retained
+        assert len(src.atl06sr_processing_levels_filtered["all"]) > 0
+
+        # Second call with identical params: served from the parquet cache.
+        src.request_atl06sr_multi_processing(
+            processing_levels=["all"],
+            region=REGION,
+            save_to_parquet=True,
+            filename="atl06sr",
+        )
+        assert calls["n"] == 1, "cache hit should not trigger a new request"
+
+    def test_param_change_regenerates(self, src, monkeypatch):
+        calls = self._patch_run(monkeypatch)
+
+        src.request_atl06sr_multi_processing(
+            processing_levels=["all"], region=REGION, save_to_parquet=True, res=20
+        )
+        assert calls["n"] == 1
+
+        # Different resolution → cached params no longer match → re-request.
+        src.request_atl06sr_multi_processing(
+            processing_levels=["all"], region=REGION, save_to_parquet=True, res=30
+        )
+        assert calls["n"] == 2
+
+    def test_records_request_metadata(self, src, monkeypatch):
+        self._patch_run(monkeypatch)
+        src.request_atl06sr_multi_processing(
+            processing_levels=["all", "ground"], region=REGION, save_to_parquet=False
+        )
+        assert src.atl06sr_request_parms["processing_levels"] == ["all", "ground"]
+        assert set(src.atl06sr_parquet_paths.keys()) == {"all", "ground"}


### PR DESCRIPTION
Closes #140.

Finishes the Altimetry source split deferred out of #130 (#139). Two independent, test-guarded refactors, one per commit. Public `Altimetry` API and the `asp_plot.altimetry` re-exports are unchanged, so `report_pipeline` / CLI call sites are untouched.

## 1. Decompose `Icesat2Source.request_atl06sr_multi_processing`
The ~225-line, network-bound request method is broken into focused helpers so the orchestrator reads as a short request → cache → ingest loop:

- `_print_time_filter_summary` — the resolved time-filter print cascade
- `_build_level_parms` — per-level SlideRule parameter assembly (shared envelope + per-surface-type custom)
- `_load_cached_atl06sr` / `_params_match_cache` — the parquet cache-parameter-comparison logic (#121)
- `_request_atl06sr_level` — the SlideRule call + WorldCover sampling + optional save

The issue flagged that this cache logic was **never exercised in CI** because it sits behind a SlideRule network call. New `tests/test_icesat2_source.py` mocks the request with a small synthetic ATL06-SR GeoDataFrame and covers: per-level parameter assembly, the parquet cache round-trip (cache hit → no re-request), and param-mismatch regeneration.

## 2. `AltimetrySource` base + per-body subclasses
- New `asp_plot/altimetry_source.py` holds the machinery every source shares: DEM bilinear sampling (`_interp_dem_at_points` / `_open_dem`), n-σ std outlier masking (`_std_outlier_mask`), and the pc_align-CSV writer (`_write_csv_to_directory`). `Icesat2Source` and the planetary sources now inherit it instead of re-implementing each.
- `PlanetarySource` splits into a body-agnostic base (dh + pc_align export) plus per-body loaders **`LolaSource`** (Moon) and **`MolaSource`** (Mars). The coordinator picks the planetary source from the DEM's body **once, at construction** — graduating from the #126 `Body` table rather than re-detecting on every load. Earth DEMs get the base, whose `load_planetary_csv` redirects to ICESat-2.

New tests cover the base helpers and the per-body dispatch; the LOLA/MOLA load tests now drive the new subclasses directly.

## Testing
`pytest` full suite: **310 passed** (was 292; +18 new). black / isort / flake8 clean.
