### PR TITLE
Reconcile WorldView (sensor) vs. Vantor (attribution) naming; fix GeoEye/QuickBird attribution (#137)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,8 +110,8 @@ The package is organized by functionality, with each module focused on a specifi
 - Coordinate utilities: `get_utm_epsg()` for determining UTM EPSG from lon/lat, `get_planetary_bounds()` for DEM bounds in planetocentric 0-360 lon/lat
 - Planetary body detection: `detect_planetary_body(dem_fn)` returns `"earth"`, `"moon"`, or `"mars"` by inspecting CRS WKT DATUM/ELLIPSOID fields
 - Subprocess utilities: `run_subprocess_command()`
-- Vantor/copyright utilities:
-  - `detect_vantor_satellite(directory)`: Checks XML files for WorldView SATIDs (WV01/WV02/WV03)
+- Vantor/copyright utilities (an **attribution** concern — named for the rights-holder — kept deliberately distinct from sensor/reader **identity**, the WorldView-named abstraction in `sensors.py`; #137):
+  - `detect_vantor_satellite(directory)`: True when an XML camera file's `SATID` matches `VANTOR_SATID_PREFIXES` — any DigitalGlobe→Maxar→Vantor-owned satellite, i.e. the WorldView family (`WV*`, incl. Legion `WVLG`), GeoEye (`GE*`), QuickBird (`QB*`), IKONOS (`IK*`) — not just WorldView. Gates the `© Vantor` overlay via `Plotter.is_vantor`
   - `add_copyright_overlay(ax)`: Adds "© Vantor {year}" text overlay to bottom-right of matplotlib axes
 - Scene metadata: `get_acquisition_dates(directory, extra_dirs=None)` reads `FIRSTLINETIME` from WorldView/Maxar XMLs and parses the capture timestamp from `AST_L1A_...` file/directory names. Returns a sorted, deduplicated list of `"YYYY-MM-DD HH:MM:SS UTC"` strings; empty if nothing is found. Used by the CLI to populate `ReportMetadata.acquisition_dates`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.18.1] - 2026-06-26
+
+### Fixed
+- **`© Vantor` attribution now covers all Vantor-owned satellites, not just WorldView** ([#137](https://github.com/uw-cryo/asp_plot/issues/137)). The copyright-overlay check (`detect_vantor_satellite`) matched only `SATID` values starting with `WV`, so GeoEye-1 (`GE01`), QuickBird (`QB02`), and IKONOS scenes — all owned by the same rights-holder (DigitalGlobe → Maxar → Vantor) — were silently left un-attributed. Detection now matches a `VANTOR_SATID_PREFIXES` whitelist (`WV` incl. WorldView Legion `WVLG`, `GE`, `QB`, `IK`). This clarifies that `is_vantor` / `detect_vantor_satellite` are an **attribution** concern (named for the company), intentionally distinct from sensor/reader **identity** (the WorldView-named abstraction in `sensors.py`); the two names are documented as deliberately different so they aren't reconciled into one.
+
 ## [1.18.0] - 2026-06-25
 
 ### Added

--- a/asp_plot/scenes.py
+++ b/asp_plot/scenes.py
@@ -26,7 +26,8 @@ class SceneFiles:
     full_stereo_directory : str
         Full path to the stereo directory.
     is_vantor : bool
-        Whether the source imagery is from a Vantor (WorldView) satellite.
+        Whether the source imagery is from a Vantor-owned satellite (WorldView
+        family, GeoEye, QuickBird, etc.); gates the "© Vantor" copyright overlay.
     left_scene_sub_fn, right_scene_sub_fn : str or None
         Paths to the left/right sub-sampled scene files.
     """

--- a/asp_plot/sensors.py
+++ b/asp_plot/sensors.py
@@ -106,6 +106,12 @@ class WorldViewMetadata(SensorMetadata):
     extract per-scene metadata, handling both single XML files and multiple XML
     tiles per scene (mosaicked with ``dg_mosaic``).
 
+    This class is named for the *sensor family* (the stable WorldView name) and
+    governs which reader parses the XML. It is intentionally distinct from the
+    *attribution* check :func:`asp_plot.utils.detect_vantor_satellite`, which is
+    named for the rights-holder (Vantor) and decides whether the "© Vantor"
+    overlay applies. The two concerns use different names on purpose; see #137.
+
     Attributes
     ----------
     directory : str

--- a/asp_plot/stereo.py
+++ b/asp_plot/stereo.py
@@ -39,7 +39,8 @@ class StereoFiles:
     full_directory : str
         Full path to the stereo directory.
     is_vantor : bool
-        Whether the source imagery is from a Vantor (WorldView) satellite.
+        Whether the source imagery is from a Vantor-owned satellite (WorldView
+        family, GeoEye, QuickBird, etc.); gates the "© Vantor" copyright overlay.
     reference_dem : str or None
         Path to the reference DEM (supplied or recovered from the stereo log).
     left_image_fn, left_image_sub_fn, right_image_sub_fn : str or None

--- a/asp_plot/utils.py
+++ b/asp_plot/utils.py
@@ -1101,9 +1101,10 @@ class Plotter:
         title : str, optional
             Plot title, default is None
         is_vantor : bool, optional
-            Whether the source imagery is from a Vantor (WorldView) satellite.
-            When True, ``plot_array`` adds a copyright overlay for panels that
-            request it via ``copyright=True``. Default is False.
+            Whether the source imagery is from a Vantor-owned satellite (the
+            WorldView family, GeoEye, QuickBird, etc.). When True, ``plot_array``
+            adds a "© Vantor" copyright overlay for panels that request it via
+            ``copyright=True``. Default is False.
         """
         self.clim_perc = clim_perc
         self.lognorm = lognorm
@@ -1196,8 +1197,8 @@ class Plotter:
             Whether to add a satellite-imagery copyright overlay, default is
             False. The overlay is only drawn when this is True *and* the Plotter
             was created with ``is_vantor=True`` (i.e. the source imagery is from
-            a Vantor/WorldView satellite). Set on the panels that display the
-            optical scenes.
+            a Vantor-owned satellite). Set on the panels that display the optical
+            scenes.
 
         Returns
         -------
@@ -1297,8 +1298,26 @@ class Plotter:
             ctx.add_basemap(ax=ax, **ctx_kwargs)
 
 
+# SATID prefixes for the DigitalGlobe -> Maxar -> Vantor satellite heritage, all
+# of which carry "© Vantor" attribution. Covers the WorldView family ("WV", incl.
+# WorldView Legion "WVLG"), GeoEye ("GE"), QuickBird ("QB"), and IKONOS ("IK").
+VANTOR_SATID_PREFIXES = ("WV", "GE", "QB", "IK")
+
+
 def detect_vantor_satellite(directory):
-    """Check if XML files in directory indicate a Vantor (WorldView) satellite.
+    """Check if XML files in directory indicate a Vantor-owned satellite.
+
+    This is an *attribution* check, distinct from sensor/reader identity: it
+    decides whether the "© Vantor" copyright overlay applies (see
+    :func:`add_copyright_overlay` and :class:`Plotter`). It is named for the
+    rights-holder (Vantor, formerly Maxar/DigitalGlobe) and matches *any* Vantor
+    satellite, not just WorldView. Sensor *identity* — which reader parses the
+    XML — is a separate concern handled by the WorldView-named abstraction in
+    :mod:`asp_plot.sensors`; the two names intentionally differ and should not be
+    "reconciled" into one.
+
+    A scene is considered Vantor-owned when an XML camera file carries a SATID
+    matching one of :data:`VANTOR_SATID_PREFIXES`.
 
     Parameters
     ----------
@@ -1308,7 +1327,8 @@ def detect_vantor_satellite(directory):
     Returns
     -------
     bool
-        True if any XML file contains a WorldView SATID (WV01, WV02, WV03, etc.).
+        True if any XML file contains a Vantor-heritage SATID (e.g. WV01-WV04,
+        WVLG, GE01, QB02).
     """
     try:
         xml_files = glob_file(directory, "*.[Xx][Mm][Ll]", all_files=True)
@@ -1320,7 +1340,7 @@ def detect_vantor_satellite(directory):
     for xml_file in xml_files:
         try:
             satid = get_xml_tag(xml_file, "SATID")
-            if satid.startswith("WV"):
+            if satid.startswith(VANTOR_SATID_PREFIXES):
                 return True
         except (ValueError, Exception):
             continue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asp_plot"
-version = "1.18.0"
+version = "1.18.1"
 license = {text = "BSD-3-Clause"}
 authors = [
   { name="Ben Purinton", email="purinton@uw.edu" },

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -586,6 +586,25 @@ class TestDetectVantorSatellite:
         """Test directory with no XML files."""
         assert detect_vantor_satellite(str(tmp_path)) is False
 
+    @staticmethod
+    def _write_xml(tmp_path, satid):
+        xml = tmp_path / f"{satid}_scene.xml"
+        xml.write_text(f"<isd><IMD><IMAGE><SATID>{satid}</SATID></IMAGE></IMD></isd>")
+        return tmp_path
+
+    @pytest.mark.parametrize("satid", ["WV03", "WVLG", "GE01", "QB02", "IK01"])
+    def test_vantor_satids_detected(self, tmp_path, satid):
+        """Any Vantor-heritage SATID (WorldView/Legion, GeoEye, QuickBird, IKONOS)
+        is attributable, not just WorldView."""
+        directory = self._write_xml(tmp_path, satid)
+        assert detect_vantor_satellite(str(directory)) is True
+
+    @pytest.mark.parametrize("satid", ["ASTER", "PHR1A", "S2A"])
+    def test_non_vantor_satids_rejected(self, tmp_path, satid):
+        """Non-Vantor SATIDs must not trigger the © Vantor attribution."""
+        directory = self._write_xml(tmp_path, satid)
+        assert detect_vantor_satellite(str(directory)) is False
+
 
 class TestAddCopyrightOverlay:
     def test_overlay_added(self):


### PR DESCRIPTION
Closes #137.

## The reframing

Issue #137 worried that `is_vantor`/`detect_vantor_satellite` (Vantor) and `WorldViewMetadata` (WorldView) were two coexisting naming conventions for the same thing, and proposed renaming the Vantor symbols to WorldView. On inspection they are **two distinct, legitimate concerns** that *should* keep different names:

| Concern | Mechanism | Name | Matches |
|---------|-----------|------|---------|
| Which reader parses the XML? | `WorldViewMetadata.detect()` (any non-ortho XML) | **WorldView** (sensor family) | any DG-heritage XML |
| Show "© Vantor"? | `is_vantor` ← `detect_vantor_satellite()` | **Vantor** (rights-holder) | **any Vantor satellite** |

`is_vantor` is used in exactly one place — `if copyright and self.is_vantor` — so it is purely an **attribution** flag. Renaming it to WorldView would mislabel it.

## The actual bug

`detect_vantor_satellite` matched `SATID.startswith("WV")`, so it **silently failed to attribute GeoEye-1 (`GE01`), QuickBird (`QB02`)**, and other Vantor-owned satellites that legally require the `© Vantor` overlay. (WorldView Legion `WVLG` was already covered since it starts `WV`.)

## Changes

- **Broaden** `detect_vantor_satellite` to a `VANTOR_SATID_PREFIXES` whitelist — `("WV", "GE", "QB", "IK")` — so every Vantor-heritage scene gets `© Vantor`.
- **Keep** the Vantor names (attribution) and the WorldView names (sensor identity); **document why they intentionally differ**, with cross-references between `utils.detect_vantor_satellite` and `sensors.WorldViewMetadata`.
- **Tests:** parametrized cases for WV03/WVLG/GE01/QB02/IK01 (detected) and non-Vantor SATIDs ASTER/PHR1A/S2A (rejected).

## Verification

`detect`/copyright tests in `test_utils.py` (15) and Vantor tests in `test_scenes.py`/`test_stereo.py` (6) all pass.

SATID values confirmed against eoreader's `MaxarSatId` enum and the PGC/Vantor constellation docs.
