### PR TITLE
Recursive XML discovery + per-CATID scene grouping (pre-req for #73)

### DIFF
--- a/asp_plot/sensors.py
+++ b/asp_plot/sensors.py
@@ -25,6 +25,7 @@ DataFrame), and ``fp_gdf`` (footprint GeoDataFrame in EPSG:4326).
 import logging
 import os
 import re
+import xml.etree.ElementTree as ET
 from abc import ABC, abstractmethod
 from datetime import datetime
 
@@ -145,24 +146,64 @@ class WorldViewMetadata(SensorMetadata):
                 "\n\nMissing XML camera files in directory. Cannot extract metadata without these.\n\n"
             )
 
+    # XML files that are delivered alongside the camera models but are *not*
+    # camera models themselves and must be ignored. Matched against the file
+    # basename, case-insensitively: ortho products (``*ortho*.xml``) and the
+    # ``README.XML`` that ships in every DigitalGlobe-heritage delivery.
+    _NON_CAMERA_XML_RE = re.compile(r"ortho|readme", re.IGNORECASE)
+
     @staticmethod
-    def _discover_xmls(directory):
-        """Glob non-ortho XML camera files in ``directory``.
+    def _filter_camera_xmls(image_list):
+        """Drop non-camera XMLs (ortho products, README.XML, ...) by basename.
+
+        Matched against the basename so a parent directory named e.g.
+        ``ortho_run/`` does not exclude otherwise-valid scenes.
+        """
+        return sorted(
+            file
+            for file in (image_list or [])
+            if not WorldViewMetadata._NON_CAMERA_XML_RE.search(os.path.basename(file))
+        )
+
+    @staticmethod
+    def _discover_xmls(directory, recursive=True):
+        """Glob camera-model XML files in ``directory``.
+
+        Searches the top level of ``directory`` first: a flat delivery or an ASP
+        processing directory keeps its camera XMLs there, so those take
+        precedence and unrelated XMLs in subdirectories are not pulled in. Only
+        when the top level has no camera XML does it fall back to a recursive
+        search, because some satellite deliveries nest the camera XML several
+        subdirectories deep (e.g. ``.../<order>/DVD_VOL_1/<order>/<scene>_PAN/
+        <scene>.XML``) alongside ``README.XML`` files that must be ignored. This
+        lets a user point at such a delivery without flattening it first, while
+        leaving the behavior of flat directories unchanged.
 
         Parameters
         ----------
         directory : str
             Path to directory to search.
+        recursive : bool, optional
+            If True (default), fall back to a recursive search when the top
+            level holds no camera XML. If False, only the top level is searched.
 
         Returns
         -------
         list
-            List of XML file paths, excluding ``*ortho*.xml`` files.
+            Sorted list of XML file paths, excluding non-camera XMLs such as
+            ``*ortho*.xml`` and ``README.XML``.
         """
-        # glob_file returns None (not []) when nothing matches
-        image_list = glob_file(directory, "*.[Xx][Mm][Ll]", all_files=True) or []
-        # Drop potential *ortho*.xml files from image_list
-        return [file for file in image_list if not re.search(r".*ortho.*\.xml", file)]
+        # glob_file returns None (not []) when nothing matches.
+        found = WorldViewMetadata._filter_camera_xmls(
+            glob_file(directory, "*.[Xx][Mm][Ll]", all_files=True)
+        )
+        if not found and recursive:
+            found = WorldViewMetadata._filter_camera_xmls(
+                glob_file(
+                    directory, "**/*.[Xx][Mm][Ll]", all_files=True, recursive=True
+                )
+            )
+        return found
 
     @classmethod
     def detect(cls, directory):
@@ -197,105 +238,143 @@ class WorldViewMetadata(SensorMetadata):
             catid_dicts.append(self.get_id_dict(catid, xml))
         return catid_dicts
 
+    @staticmethod
+    def _read_catid(xml_file):
+        """Return the CATID of an XML file, or None if it has none.
+
+        A delivery may contain XML files that are not camera models (e.g. a
+        stray metadata sidecar) and therefore carry no ``CATID`` tag. Those are
+        not camera scenes and should be skipped rather than crashing discovery,
+        so this swallows the missing-tag/parse errors and returns None.
+
+        Parameters
+        ----------
+        xml_file : str
+            Path to the XML file.
+
+        Returns
+        -------
+        str or None
+            The catalog ID, or None if the file has no ``CATID`` tag or cannot
+            be parsed as XML.
+        """
+        try:
+            return get_xml_tag(xml_file, "CATID")
+        except (ValueError, ET.ParseError):
+            return None
+
     def get_catid_xmls(self):
         """
-        Get XML files associated with each catalog ID.
+        Get a single representative XML file for each catalog ID.
 
-        Checks for multiple XML files for each catalog ID and handles mosaicking
-        if needed.
+        Groups the discovered XML files by their catalog ID (read from the XML
+        content, not the filename) and resolves each scene to one XML: a scene
+        delivered as a single XML is used as-is, while a scene tiled across
+        multiple XMLs is mosaicked into one with ``dg_mosaic``.
 
         Returns
         -------
         dict
-            Dictionary mapping catalog IDs to XML file paths
+            Dictionary mapping catalog IDs to a single XML file path.
+
+        Raises
+        ------
+        ValueError
+            If none of the discovered XML files contain a ``CATID`` tag.
 
         Notes
         -----
-        If more than two XML files are found, they will be mosaicked using
-        dg_mosaic before proceeding.
+        Mosaicking is decided per catalog ID, so a directory holding many
+        distinct single-tile scenes is *not* mosaicked just because it contains
+        more than two XML files. Mosaicking a tiled scene requires ``dg_mosaic``
+        from the NASA Ames Stereo Pipeline on the system path.
         """
-        # First check for multiple XML files and dg_mosaic if needed
-        if len(self.image_list) > 2:
-            print(
-                "\nMore than two XML files found in directory. Mosaicking before proceeding.\n"
-            )
-            self.mosaic_multiple_xmls()
-
-        # Get CATIDs
-        catid_xmls = {}
+        # Group every discovered XML by CATID read from XML content (filenames
+        # are not reliable). Files without a CATID are not camera models (e.g. a
+        # README.XML that slipped past the name filter) and are skipped with a
+        # warning rather than crashing.
+        catid_groups = {}
         for xml_file in self.image_list:
-            catid = get_xml_tag(xml_file, "CATID")
-            catid_xmls[catid] = xml_file
+            catid = self._read_catid(xml_file)
+            if catid is None:
+                logger.warning(
+                    "Skipping XML without a CATID tag (not a camera model): %s",
+                    xml_file,
+                )
+                continue
+            catid_groups.setdefault(catid, []).append(xml_file)
 
-        # TODO: need to improve logic and looping here and in get_id_dict for dictionary creation when
-        # there are multiple XML files for a given scene
-        # use ~/Desktop/asp-plot-examples/antarctica/tiled_xmls_example for testing this
+        if not catid_groups:
+            raise ValueError(
+                "\n\nNo XML camera files with a CATID tag found in directory.\n\n"
+            )
+
+        # Resolve each CATID to a single representative XML. A mosaic output
+        # (``*.r100.xml`` / ``*.r50.xml``) is only a regenerable intermediate
+        # when raw tiles for the same CATID are also present; when it is the
+        # only XML for a CATID it *is* the delivered camera and is used as-is.
+        catid_xmls = {}
+        for catid, group in sorted(catid_groups.items()):
+            raw_tiles = sorted(
+                f for f in group if not re.search(r"\.r100\.|\.r50\.", f)
+            )
+            if not raw_tiles:
+                # Delivered as a single, already-mosaicked XML (e.g. *.r100.xml).
+                catid_xmls[catid] = sorted(group)[0]
+            elif len(raw_tiles) == 1:
+                # Single tile: use it directly, no mosaicking needed.
+                catid_xmls[catid] = raw_tiles[0]
+            else:
+                print(
+                    f"\nCATID {catid} is tiled across {len(raw_tiles)} XMLs. "
+                    "Mosaicking before proceeding.\n"
+                )
+                catid_xmls[catid] = self._mosaic_tiles(catid, raw_tiles)
 
         return catid_xmls
 
-    def mosaic_multiple_xmls(self):
+    def _mosaic_tiles(self, catid, tile_xmls):
         """
-        Mosaic multiple XML files for each catalog ID.
+        Mosaic the tile XMLs of a single catalog ID into one XML.
 
-        Uses dg_mosaic to merge multiple XML files for the same catalog ID
-        into a single XML file. This is needed when a scene is composed of
-        multiple image tiles.
+        Uses ``dg_mosaic`` to merge the image tiles of one scene into a single
+        camera XML. An existing mosaic output is reused rather than regenerated.
+
+        Parameters
+        ----------
+        catid : str
+            Catalog ID the tiles belong to (used for the output filename).
+        tile_xmls : list of str
+            Paths to the tile XML files for this catalog ID.
 
         Returns
         -------
-        None
-            Updates the image_list attribute with mosaicked XML files
+        str
+            Path to the mosaicked ``*.r100.xml`` file.
 
         Notes
         -----
         Requires dg_mosaic from the NASA Ames Stereo Pipeline to be installed
         and available in the system path.
         """
-        # Drop existing *.r100.* and *.r50.* files from image_list if they are present
-        self.image_list = [
-            file
-            for file in self.image_list
-            if not re.search(r"\.r100\..*|\.r50\..*", file)
-        ]
+        output_xml = os.path.join(self.directory, f"{catid}_asp_plot_dg_mosaic")
+        output_xml_r100 = f"{output_xml}.r100.xml"
 
-        # Group XML files by CATID
-        catid_xml_dict = {}
-        for xml_file in self.image_list:
-            catid = get_xml_tag(xml_file, "CATID")
-            if catid not in catid_xml_dict:
-                catid_xml_dict[catid] = []
-            catid_xml_dict[catid].append(xml_file)
+        if not os.path.exists(output_xml_r100):
+            # Build the command string instead of a list, needed for subprocess call, .split() below
+            xml_files = " ".join(tile_xmls)
+            command = (
+                f"dg_mosaic --skip-tif-gen --output-prefix {output_xml} {xml_files}"
+            )
 
-        # Convert lists to space-separated strings
-        catid_xml_dict = {
-            catid: " ".join(xml_files) for catid, xml_files in catid_xml_dict.items()
-        }
+            print(f"\nRunning dg_mosaic with command: {command}\n")
 
-        # Run dg_mosaic with: dg_mosaic --skip-tif-gen --output-prefix <NAME> <SPACE SEPARATED XML FILES>
-        output_xmls = []
-        for catid, xml_files in catid_xml_dict.items():
-            output_xml = os.path.join(self.directory, f"{catid}_asp_plot_dg_mosaic")
-            output_xml_r100 = f"{output_xml}.r100.xml"
+            # Run the command
+            run_subprocess_command(command.split())
+        else:
+            print(f"\nUsing existing mosaicked XML file: {output_xml_r100}\n")
 
-            if not os.path.exists(output_xml_r100):
-                # Build the command string instead of a list, needed for subprocess call, .split() below
-                command = (
-                    f"dg_mosaic --skip-tif-gen --output-prefix {output_xml} {xml_files}"
-                )
-
-                print(f"\nRunning dg_mosaic with command: {command}\n")
-
-                # Run the command
-                run_subprocess_command(command.split())
-            else:
-                print(f"\nUsing existing mosaicked XML file: {output_xml_r100}\n")
-
-            output_xmls.append(output_xml_r100)
-
-        # Then create the new image list with just the mosaicked XML files
-        self.image_list = []
-        for output_xml in output_xmls:
-            self.image_list.append(output_xml)
+        return output_xml_r100
 
     def get_id_dict(self, catid, xml, geteph=True):
         """

--- a/asp_plot/utils.py
+++ b/asp_plot/utils.py
@@ -30,7 +30,7 @@ def nmad(a, c=1.4826):
     return np.nanmedian(np.fabs(a - np.nanmedian(a))) * c
 
 
-def glob_file(directory, *patterns, all_files=False):
+def glob_file(directory, *patterns, all_files=False, recursive=False):
     """
     Find files matching pattern(s) in a directory.
 
@@ -47,6 +47,9 @@ def glob_file(directory, *patterns, all_files=False):
     all_files : bool, optional
         If True, return all matching files; if False, return only the first match.
         Default is False.
+    recursive : bool, optional
+        If True, enable recursive globbing so a ``**`` in a pattern matches this
+        directory and all subdirectories. Default is False.
 
     Returns
     -------
@@ -59,10 +62,11 @@ def glob_file(directory, *patterns, all_files=False):
     >>> first_tif = glob_file("/path/to/dir", "*.tif")
     >>> all_tifs = glob_file("/path/to/dir", "*.tif", all_files=True)
     >>> dem_file = glob_file("/path/to/dir", "*-DEM.tif", "*_dem.tif")
+    >>> nested = glob_file("/path/to/dir", "**/*.xml", all_files=True, recursive=True)
     """
     directory = os.path.expanduser(directory)
     for pattern in patterns:
-        files = glob.glob(os.path.join(directory, pattern))
+        files = glob.glob(os.path.join(directory, pattern), recursive=recursive)
         if files:
             if all_files:
                 return files

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -1,3 +1,6 @@
+import shutil
+from pathlib import Path
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -8,6 +11,12 @@ from asp_plot.sensors import (
     WorldViewMetadata,
     sensor_for_directory,
 )
+
+# The two committed single-scene WorldView camera XMLs at the top level of
+# tests/test_data (one *.r100.xml per CATID, no tiles).
+TEST_DATA_DIR = Path("tests/test_data")
+CAM_A = TEST_DATA_DIR / "10300100D0772D00.r100.xml"
+CAM_B = TEST_DATA_DIR / "10300100D12D7400.r100.xml"
 
 
 class TestWorldViewMetadata:
@@ -94,3 +103,126 @@ class TestSensorDetection:
     def test_sensor_for_directory_no_match_raises(self, tmp_path):
         with pytest.raises(ValueError, match="No supported sensor metadata"):
             sensor_for_directory(str(tmp_path))
+
+
+class TestWorldViewDiscovery:
+    """Shallow-first XML discovery and non-camera XML exclusion."""
+
+    def test_finds_xml_nested_several_dirs_deep(self, tmp_path):
+        # Real deliveries nest the camera XML well below the directory handed in.
+        nested = tmp_path / "order" / "DVD_VOL_1" / "order" / "scene_PAN"
+        nested.mkdir(parents=True)
+        shutil.copy(CAM_A, nested / "camera.xml")
+
+        found = WorldViewMetadata._discover_xmls(str(tmp_path))
+        assert [Path(f).name for f in found] == ["camera.xml"]
+
+    def test_top_level_takes_precedence_over_nested(self, tmp_path):
+        # A flat delivery / processing dir keeps its camera XMLs at the top
+        # level, so discovery uses those and does NOT descend into unrelated
+        # subdirectories (which would change report behavior).
+        shutil.copy(CAM_A, tmp_path / "top.xml")
+        nested = tmp_path / "subdir"
+        nested.mkdir()
+        shutil.copy(CAM_B, nested / "nested.xml")
+
+        found = WorldViewMetadata._discover_xmls(str(tmp_path))
+        assert [Path(f).name for f in found] == ["top.xml"]
+
+    def test_non_recursive_ignores_nested(self, tmp_path):
+        nested = tmp_path / "scene_PAN"
+        nested.mkdir()
+        shutil.copy(CAM_A, nested / "camera.xml")
+
+        assert WorldViewMetadata._discover_xmls(str(tmp_path), recursive=False) == []
+
+    def test_excludes_readme_and_ortho(self, tmp_path):
+        pan = tmp_path / "scene_PAN"
+        pan.mkdir()
+        shutil.copy(CAM_A, pan / "camera.xml")
+        # Decoys that ship alongside camera XMLs and must be ignored by name.
+        (tmp_path / "500647760070_01_README.XML").write_text("<README/>")
+        (pan / "scene-ortho.xml").write_text("<isd/>")
+
+        found = WorldViewMetadata._discover_xmls(str(tmp_path))
+        assert [Path(f).name for f in found] == ["camera.xml"]
+
+    def test_detect_uses_recursive_discovery(self, tmp_path):
+        nested = tmp_path / "a" / "b" / "scene_PAN"
+        nested.mkdir(parents=True)
+        shutil.copy(CAM_A, nested / "camera.xml")
+        assert WorldViewMetadata.detect(str(tmp_path)) is True
+
+
+class TestWorldViewSceneGrouping:
+    """Grouping discovered XMLs into scenes by CATID read from content."""
+
+    @staticmethod
+    def _scene_with_catid(src, dst, new_catid):
+        """Copy ``src`` to ``dst`` with its CATID rewritten to ``new_catid``."""
+        # CAM_A's CATID is its filename stem; rewrite every occurrence so the
+        # copy reads as a distinct scene.
+        text = Path(src).read_text().replace("10300100D0772D00", new_catid)
+        Path(dst).write_text(text)
+
+    def test_distinct_single_tile_scenes_not_mosaicked(self, tmp_path):
+        # Three distinct single-tile scenes in one flat directory must NOT be
+        # treated as tiles of one scene just because there are more than two.
+        shutil.copy(CAM_A, tmp_path / "a.xml")
+        shutil.copy(CAM_B, tmp_path / "b.xml")
+        self._scene_with_catid(CAM_A, tmp_path / "c.xml", "10300100DEADBE00")
+
+        reader = WorldViewMetadata(directory=str(tmp_path))
+        catid_xmls = reader.get_catid_xmls()
+
+        assert set(catid_xmls) == {
+            "10300100D0772D00",
+            "10300100D12D7400",
+            "10300100DEADBE00",
+        }
+        # Each scene maps to one of the untouched inputs ...
+        assert {Path(v).name for v in catid_xmls.values()} == {
+            "a.xml",
+            "b.xml",
+            "c.xml",
+        }
+        # ... and no dg_mosaic output was produced.
+        assert not list(tmp_path.glob("*_asp_plot_dg_mosaic*"))
+
+    def test_skips_xml_without_catid(self, tmp_path, caplog):
+        shutil.copy(CAM_A, tmp_path / "a.xml")
+        shutil.copy(CAM_B, tmp_path / "b.xml")
+        # A non-camera XML whose name does not match readme/ortho, so it passes
+        # discovery and must be skipped by the content (CATID) check.
+        (tmp_path / "sidecar.xml").write_text("<metadata><note>hi</note></metadata>")
+
+        reader = WorldViewMetadata(directory=str(tmp_path))
+        with caplog.at_level("WARNING"):
+            catid_xmls = reader.get_catid_xmls()
+
+        assert set(catid_xmls) == {"10300100D0772D00", "10300100D12D7400"}
+        assert "without a CATID" in caplog.text
+
+    def test_all_xmls_without_catid_raises(self, tmp_path):
+        (tmp_path / "sidecar.xml").write_text("<metadata/>")
+        reader = WorldViewMetadata(directory=str(tmp_path))
+        with pytest.raises(ValueError, match="No XML camera files with a CATID"):
+            reader.get_catid_xmls()
+
+    def test_lone_r100_delivery_used_as_is(self):
+        # A scene delivered as a single *.r100.xml is the camera itself and must
+        # not be dropped as a regenerable mosaic intermediate.
+        reader = WorldViewMetadata(directory=str(TEST_DATA_DIR))
+        catid_xmls = reader.get_catid_xmls()
+        assert set(catid_xmls) == {"10300100D0772D00", "10300100D12D7400"}
+        assert all(v.endswith(".r100.xml") for v in catid_xmls.values())
+
+    def test_tiled_scene_reuses_existing_mosaic(self):
+        # Raw tiles + a pre-existing mosaic: grouped to one mosaic per CATID
+        # without invoking dg_mosaic (the committed mosaic output is reused).
+        reader = WorldViewMetadata(directory="tests/test_data/tiled_xmls")
+        catid_xmls = reader.get_catid_xmls()
+        assert set(catid_xmls) == {"10200100A1865800", "10200100A37C1C00"}
+        assert all(
+            v.endswith("_asp_plot_dg_mosaic.r100.xml") for v in catid_xmls.values()
+        )


### PR DESCRIPTION
## Summary

Pre-requisite groundwork for #73 (**does not close it**). Makes XML camera-model discovery and scene grouping robust enough to point the tool at *real, messy* satellite deliveries — the necessary foundation before the N>2 stereo-geometry plotting work in #73.

Validated against real WorldView deliveries (SpaceNet **UCSD** WV3 and **Atlanta** WV2 metadata, pulled from the public `s3://spacenet-dataset` buckets).

## Why

Running the *current* code against real deliveries surfaced three concrete defects:

| Scenario | Old behavior |
|---|---|
| Camera XML nested 3–4 dirs deep (`.../DVD_VOL_1/<order>/<scene>_PAN/<scene>.XML`) | Not found — discovery globbed only one directory level |
| `README.XML` shipped alongside the camera XMLs | Wrongly ingested → `ValueError: Tag 'CATID' not found` (only `*ortho*.xml` was excluded) |
| A directory of N *distinct* single-tile scenes | Treated as N *tiles of one scene* and mosaicked, because grouping keyed off "more than two XMLs present" |

These are exactly the messy-directory concerns called out in the body of #73 ("XML ... could be 3 or 4 subdir deep, with other XML files (like README.XML) ... that should be ignored", "should not assume that CATID is in the filenames").

## Changes

- **`_discover_xmls` is now shallow-first**: it searches the top level of the directory and falls back to a **recursive** search only when the top level holds no camera XML. A flat delivery / ASP processing directory keeps using its top-level XMLs (no behavior change for the existing report tool), while a user can still point at a delivery that nests the camera XML several dirs deep.
- Non-camera XMLs (`*ortho*.xml`, `README.XML`) are excluded by basename (`_filter_camera_xmls`).
- **`glob_file`** gains a `recursive` flag for `**` patterns.
- **`get_catid_xmls`** groups XMLs by **CATID read from XML content** (not filenames), skips XMLs that have no CATID (with a warning) instead of crashing, and mosaics **per-CATID only for genuine multi-tile scenes**. A lone `*.r100.xml` delivery is used as-is.
- **`mosaic_multiple_xmls` → `_mosaic_tiles`**: mosaics one CATID's tiles and returns its `.r100.xml` (reusing an existing mosaic output).
- **Tests**: new `tmp_path`-based coverage for shallow-first/recursive discovery, README/ortho exclusion, top-level precedence, per-CATID grouping (distinct scenes not mosaicked, content-based skip, lone `.r100.xml`, tiled reuse); and the stereo-geometry tests now render with `add_basemap=False` so they no longer depend on a live tile server (deterministic + ~200x faster).

## Verification

Against real data in a local examples dir (not committed):

- **UCSD** (point at `scenes/` top; XMLs 4 deep + 12 `README.XML` decoys): top level has none → recursive fallback finds 6 camera XMLs, READMEs excluded, **6 distinct CATIDs, no needless mosaic**.
- **Atlanta** (one CATID, 3 tiles under different `*_PAN/` subdirs): correctly grouped into 1 CATID and mosaicked.
- **`tests/test_data`** (two top-level `*.r100.xml`): shallow discovery returns exactly those two; the report pipeline is unaffected and never descends into `tiled_xmls/`.
- **`tests/test_data/tiled_xmls`** (raw tiles + existing mosaics): mosaic reused → 2 scenes.

Targeted suites green locally: `test_sensors`, `test_stereo_geometry`, `test_stereopair_metadata_parser`, `test_report_pipeline`, `test_processing_parameters`, `test_utils`.

## Follow-up (the rest of #73)

- Generalize `StereopairMetadataParser` / plotting from a 2-scene pair to an N-scene collection (skyplot/mapview across all pairs).
- Flexible CLI input (`geom_plot *.XML` / list of dirs).
- Optional STAC ingestion path.

## Note

`detect_vantor_satellite` (report attribution) remains non-recursive — it's a separate code path that runs on ASP processing directories with a known layout; left unchanged to avoid scope creep.
