### PR TITLE
Stop tests hanging on contextily basemap network fetches

### DIFF
--- a/asp_plot/altimetry_plots.py
+++ b/asp_plot/altimetry_plots.py
@@ -363,6 +363,18 @@ class AltimetryPlotter:
 
         x_bounds = []
         y_bounds = []
+        # CRS to reproject every panel into. This is independent of whether a
+        # basemap is drawn: a basemap is only fetched when the caller passes
+        # contextily kwargs (e.g. source=...). Previously this CRS was injected
+        # into ``ctx_kwargs``, which made the ``if ctx_kwargs`` basemap guard
+        # below always true and forced a tile download on every call (a network
+        # hang in offline/CI runs).
+        if map_crs:
+            crs = map_crs
+        elif ctx_kwargs:
+            crs = ctx_kwargs.get("crs", "EPSG:4326")
+        else:
+            crs = "EPSG:4326"
         for ax, time_stamp in zip(axes, time_stamps):
             key_to_plot = f"{key}{time_stamp}"
 
@@ -379,13 +391,6 @@ class AltimetryPlotter:
                 continue
 
             atl06sr = filtered[key_to_plot]
-            if map_crs:
-                crs = map_crs
-                ctx_kwargs["crs"] = map_crs
-            elif ctx_kwargs:
-                crs = ctx_kwargs["crs"]
-            else:
-                crs = "EPSG:4326"
             atl06sr_sorted = atl06sr.sort_values(by="h_mean").to_crs(crs)
             bounds = atl06sr_sorted.total_bounds
             x_bounds.extend([bounds[0], bounds[2]])
@@ -424,6 +429,7 @@ class AltimetryPlotter:
                 min(y_bounds) - padding * y_range, max(y_bounds) + padding * y_range
             )
             if ctx_kwargs:
+                ctx_kwargs.setdefault("crs", crs)
                 ctx.add_basemap(ax=ax, **ctx_kwargs)
 
         suptitle = f"{title}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,36 @@
+"""Shared pytest configuration.
+
+Blocks outbound network access for the whole test suite. No test needs the
+network — ICESat-2/SlideRule requests are pre-fetched into parquet fixtures and
+contextily basemaps are disabled in plotting tests. A stray basemap fetch
+(``contextily.add_basemap``) otherwise blocks on an uninterruptible socket read
+and hangs CI for the full job timeout. With this guard such a call fails fast
+and loudly instead, so the offending test is obvious rather than a silent hang.
+
+Loopback connections are still allowed so local IPC (e.g. joblib worker
+backends, which contextily uses) keeps working.
+"""
+
+import socket
+
+import pytest
+
+_real_connect = socket.socket.connect
+_LOOPBACK_HOSTS = {"127.0.0.1", "::1", "localhost"}
+
+
+def _guarded_connect(self, address):
+    host = address[0] if isinstance(address, (tuple, list)) else address
+    if host not in _LOOPBACK_HOSTS:
+        raise RuntimeError(
+            f"Network access is disabled during tests (attempted connection to "
+            f"{host!r}). Tests must use local fixtures; disable basemaps with "
+            f"add_basemap=False / omit contextily kwargs."
+        )
+    return _real_connect(self, address)
+
+
+@pytest.fixture(autouse=True)
+def _block_network(monkeypatch):
+    """Fail fast on any non-loopback socket connection (autouse, every test)."""
+    monkeypatch.setattr(socket.socket, "connect", _guarded_connect)

--- a/tests/test_altimetry.py
+++ b/tests/test_altimetry.py
@@ -101,6 +101,28 @@ class TestAltimetry:
                 f"plot_atl06sr_time_stamps() method raised an exception: {str(e)}"
             )
 
+    def test_plot_atl06sr_time_stamps_no_basemap_by_default(self, icesat, monkeypatch):
+        # Regression: with no contextily kwargs, the method must NOT fetch a
+        # basemap (which would hit the network and hang offline / in CI). The
+        # default map_crs must not silently enable it.
+        import asp_plot.altimetry_plots as ap
+
+        calls = []
+        monkeypatch.setattr(ap.ctx, "add_basemap", lambda *a, **k: calls.append(k))
+        icesat.plot_atl06sr_time_stamps()
+        assert calls == []
+
+    def test_plot_atl06sr_time_stamps_basemap_when_requested(self, icesat, monkeypatch):
+        # When the caller passes contextily kwargs, a basemap is drawn and the
+        # reprojection CRS is forwarded to contextily.
+        import asp_plot.altimetry_plots as ap
+
+        calls = []
+        monkeypatch.setattr(ap.ctx, "add_basemap", lambda *a, **k: calls.append(k))
+        icesat.plot_atl06sr_time_stamps(source="dummy_source")
+        assert len(calls) >= 1
+        assert all(c.get("crs") for c in calls)
+
     def test_plot_atl06sr(self, icesat):
         try:
             icesat.plot_atl06sr()

--- a/tests/test_stereo_geometry.py
+++ b/tests/test_stereo_geometry.py
@@ -10,8 +10,11 @@ matplotlib.use("Agg")
 class TestStereoGeometryPlotter:
     @pytest.fixture
     def stereo_geometry_plotter(self):
+        # add_basemap=False keeps the test offline; a True default would fetch
+        # contextily tiles from a live server and hang/flake in CI.
         stereo_geometry_plotter = StereoGeometryPlotter(
             directory="tests/test_data",
+            add_basemap=False,
         )
         return stereo_geometry_plotter
 
@@ -19,6 +22,7 @@ class TestStereoGeometryPlotter:
     def stereo_geometry_plotter_tiled(self):
         stereo_geometry_plotter = StereoGeometryPlotter(
             directory="tests/test_data/tiled_xmls",
+            add_basemap=False,
         )
         return stereo_geometry_plotter
 


### PR DESCRIPTION
## Summary

Fixes the test suite hanging on CI (runs ballooning to 25–37 min and getting cancelled). Root cause: an **uninterruptible socket read inside `contextily.add_basemap`** when the OSM tile server stalls — a thread-based timeout can't even kill it.

After this change the **full suite runs offline in ~43s (351 passed)**.

## Three things, one root cause

1. **`plot_atl06sr_time_stamps` always fetched a basemap.** It used `if ctx_kwargs:` as the basemap on/off switch, but earlier in the method it injected `ctx_kwargs["crs"] = map_crs` — and `map_crs` defaults to `"EPSG:4326"`. So `ctx_kwargs` was never empty, the guard was always true, and **every call hit the network, even with no contextily kwargs**. Fixed by separating the reprojection CRS from the basemap toggle, so a basemap is only drawn when the caller actually passes contextily kwargs (this is exactly how the sibling `plot_atl06sr` already behaves). The report pipeline is unaffected — it passes `ctx_kwargs` (with `source`/`crs`) only when `add_basemap=True`, and it doesn't call `time_stamps` at all.

2. **`stereo_geometry` tests rendered with the default `add_basemap=True`** → live tile fetch. Now pass `add_basemap=False` (these only assert the figure renders; the basemap imagery isn't checked).

3. **Nothing stopped a stray fetch from hanging the whole job.** Added `tests/conftest.py` with an autouse guard that blocks non-loopback socket connections, so any accidental network call **fails fast and names itself** instead of hanging. Loopback stays open so joblib/IPC (which contextily uses) keeps working.

## Why a guard *and* the targeted fixes

The targeted fixes make the offending tests pass; the guard makes the whole suite immune to this class of hang going forward (a future plot test that forgets `add_basemap=False` fails loudly in CI rather than silently hanging for the job timeout).

## Verification

- Full suite with the guard active: **351 passed in ~43s**, no failures, no hangs.
- New regression tests assert `plot_atl06sr_time_stamps()` does **not** fetch a basemap by default, and **does** (with the CRS forwarded) when contextily kwargs are passed.

## Note

This is a standalone fix off `main`. The in-flight #150 (recursive XML discovery) will be rebased on top once this merges; its own `stereo_geometry` offline tweak becomes redundant and will drop out during the rebase.
