### PR TITLE
Flexible geom_plot input: XML files, dirs, and globs (pre-req for #73)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,12 +160,12 @@ The package is organized by functionality, with each module focused on a specifi
 - `find_mapproject_commands(directories, stereo_command=None)`: scans dirs (processing root, BA dir, stereo dir) for all `*.tif`/`*.tiff` and keeps those carrying the tag signature — **identity is decided by the file's own metadata, never by filename**, so there is no naming-convention dependency (reading a GeoTIFF header is cheap; the `NotGeoreferencedWarning` from raw non-georef inputs is silenced). Dedupes by the reconstructed command string (identical scene reached via two dirs collapses; distinct left/right both show). When `stereo_command` is given, a discovered output is kept only if its filename appears in that command — this scopes the result to the run being reported, so a non-mapprojected run sharing a parent dir with mapprojected scenes (the `stereo/` + `stereo_no_mapproj/` layout) does **not** spuriously list a mapproject step. It's a whole-token basename membership test (the output basename must equal one of the stereo command's argument basenames — not a raw substring, so `run.tif` can't match `prun.tif`), not positional parsing. `ProcessingParameters.get_mapproject_commands(stereo_command)` passes the parsed stereo command; `report.py` renders the results under "Mapproject Command(s)" on the Processing Parameters page (via the module-level `_render_command_block` helper, shared with the bundle_adjust/stereo/point2dem commands)
 
 **`sensors.py`** - Sensor-specific scene metadata readers (issue #25)
-- `SensorMetadata` ABC defining the reader interface (`detect` + `get_scene_dicts`) and the sensor-agnostic scene-dict schema, mirroring the `bodies.py` registry pattern so adding ASTER/HiRISE/etc. is a new subclass with no change to the geometry code
-- `WorldViewMetadata(SensorMetadata)`: the WorldView/Maxar XML logic (file discovery, `dg_mosaic` tiling, per-scene extraction, ephemeris/attitude/footprint) moved verbatim out of the parser. Named after the satellite family rather than the (twice-renamed: DigitalGlobe → Maxar → Vantor) company; the same format also covers GeoEye-1/QuickBird/IKONOS
-- `SENSORS` registry + `sensor_for_directory()` detection
+- `SensorMetadata` ABC defining the reader interface (`detect` + `detect_files` + `get_scene_dicts`) and the sensor-agnostic scene-dict schema, mirroring the `bodies.py` registry pattern so adding ASTER/HiRISE/etc. is a new subclass with no change to the geometry code
+- `WorldViewMetadata(SensorMetadata)`: the WorldView/Maxar XML logic (file discovery, `dg_mosaic` tiling, per-scene extraction, ephemeris/attitude/footprint) moved verbatim out of the parser. Named after the satellite family rather than the (twice-renamed: DigitalGlobe → Maxar → Vantor) company; the same format also covers GeoEye-1/QuickBird/IKONOS. Constructible from either a `directory=` (recursive discovery) or an explicit `image_list=` (already-resolved XML paths); non-camera files (`README.XML`, ortho) are filtered out either way
+- `SENSORS` registry + two detection entry points: `sensor_for_directory()` (scans a directory) and `sensor_for_inputs()` (accepts a mixed list of files/dirs/globs). The latter routes through `resolve_xml_inputs()`, which expands directories (recursively), globs, and plain paths into a deduped, sorted XML list — this is what lets `stereo_geom *.XML` / explicit files / a delivery dir all work without a fixed structure
 
 **`stereopair_metadata_parser.py`** - `StereopairMetadataParser` class
-- Now a **sensor-agnostic orchestrator** (issue #25): detects a reader via `sensor_for_directory()`, delegates scene discovery/extraction to it, and keeps only the pair-level geometry
+- Now a **sensor-agnostic orchestrator** (issue #25): detects a reader via `sensor_for_directory()` (from `directory=`) or `sensor_for_inputs()` (from a mixed `inputs=` list of files/dirs/globs), delegates scene discovery/extraction to it, and keeps only the pair-level geometry
 - Computes stereo geometry metrics: convergence angle, base-to-height ratio, bisector elevation, asymmetry
 - Provides spatial utilities: `get_pair_utm_epsg()`, `get_intersection_bounds()`, `get_scene_bounds()`
 - `get_catid_dicts()` returns dictionaries per catalog ID with ephemeris, attitude, and geometry data (sourced from the sensor reader)
@@ -321,6 +321,7 @@ All CLI tools are in `asp_plot/cli/` and use Click for argument parsing:
 - Wrapper for `StereoGeometryPlotter`
 - Creates skyplot and map view from XML camera files
 - Supports multiple XMLs with automatic mosaicking
+- Accepts positional `INPUTS` (any mix of XML files, directories, and globs — e.g. `stereo_geom *.XML`); falls back to `--directory` when no positional inputs are given. Both paths funnel into the same plotter (`inputs=` vs `directory=`)
 
 **`gallery.py`** - DEM gallery tool (`gallery` command)
 - Wrapper for `GalleryPlotter`; lays out many DEMs as a grid sharing one color scale

--- a/asp_plot/cli/stereo_geom.py
+++ b/asp_plot/cli/stereo_geom.py
@@ -6,11 +6,14 @@ from asp_plot.stereo_geometry import StereoGeometryPlotter
 
 
 @click.command()
+@click.argument("inputs", nargs=-1, type=click.Path())
 @click.option(
     "--directory",
-    prompt=True,
-    default="./",
-    help="Directory containing XML files for stereo geometry analysis. Default: current directory.",
+    default=None,
+    help=(
+        "Directory containing XML files for stereo geometry analysis. "
+        "Used when no positional INPUTS are given. Default: current directory."
+    ),
 )
 @click.option(
     "--add_basemap",
@@ -31,6 +34,7 @@ from asp_plot.stereo_geometry import StereoGeometryPlotter
     help="Filename for the output plot. Default: Directory name with _stereo_geom.png suffix.",
 )
 def main(
+    inputs,
     directory,
     add_basemap,
     output_directory,
@@ -38,30 +42,46 @@ def main(
 ):
     """
     Generate stereo geometry plots for WorldView XML files.
-    This tool creates a skyplot and map visualization of the satellite positions and ground footprints.
+
+    This tool creates a skyplot and map visualization of the satellite positions
+    and ground footprints. INPUTS may be any mix of XML files, directories, and
+    glob patterns and need not follow a fixed directory structure, e.g.:
+
+        stereo_geom *.XML
+
+        stereo_geom scene1.xml scene2.xml
+
+        stereo_geom my_delivery_dir/
+
+    If no INPUTS are given, --directory is used (default: current directory).
     """
-    directory = os.path.expanduser(directory)
-    if output_directory:
-        output_directory = os.path.expanduser(output_directory)
+    # Positional INPUTS take precedence; otherwise fall back to --directory.
+    if inputs:
+        inputs = [os.path.expanduser(i) for i in inputs]
+        plotter = StereoGeometryPlotter(inputs=inputs, add_basemap=add_basemap)
+        source_desc = " ".join(inputs)
+        # Base directory for default output paths (resolved by the parser).
+        base_directory = plotter.directory
+    else:
+        base_directory = os.path.expanduser(directory or "./")
+        plotter = StereoGeometryPlotter(
+            directory=base_directory, add_basemap=add_basemap
+        )
+        source_desc = base_directory
 
-    print(f"\nProcessing stereo geometry for XML files in {directory}\n")
+    print(f"\nProcessing stereo geometry for XML files in {source_desc}\n")
 
-    # Get directory name for default output filename
-    dir_name = os.path.split(directory.rstrip("/\\"))[-1]
-
-    # Set default output directory to input directory
+    # Derive default output directory/filename from the base directory.
+    dir_name = os.path.split(base_directory.rstrip("/\\"))[-1]
     if output_directory is None:
-        output_directory = directory
-
-    # Set default output filename using directory name
+        output_directory = base_directory
+    else:
+        output_directory = os.path.expanduser(output_directory)
     if output_filename is None:
         output_filename = f"{dir_name}_stereo_geom.png"
 
-    # Create output directory if it doesn't exist
     os.makedirs(output_directory, exist_ok=True)
 
-    # Create the geometry plotter and generate the plot
-    plotter = StereoGeometryPlotter(directory, add_basemap=add_basemap)
     plotter.dg_geom_plot(save_dir=output_directory, fig_fn=output_filename)
 
     print(

--- a/asp_plot/sensors.py
+++ b/asp_plot/sensors.py
@@ -22,6 +22,7 @@ attributes (``meansataz``, ``meansatel``, ``meanoffnadirviewangle``,
 DataFrame), and ``fp_gdf`` (footprint GeoDataFrame in EPSG:4326).
 """
 
+import glob
 import logging
 import os
 import re
@@ -87,6 +88,26 @@ class SensorMetadata(ABC):
         """
         raise NotImplementedError
 
+    @classmethod
+    @abstractmethod
+    def detect_files(cls, image_list):
+        """Return True if this reader can handle the files in ``image_list``.
+
+        The file-list counterpart of :meth:`detect`, used when the sensor must
+        be chosen from an explicit list of inputs rather than a directory.
+
+        Parameters
+        ----------
+        image_list : list of str
+            Candidate metadata file paths.
+
+        Returns
+        -------
+        bool
+            Whether this sensor's metadata files are present in the list.
+        """
+        raise NotImplementedError
+
     @abstractmethod
     def get_scene_dicts(self):
         """Return a list of per-scene metadata dictionaries.
@@ -123,27 +144,53 @@ class WorldViewMetadata(SensorMetadata):
 
     name = "WorldView"
 
-    def __init__(self, directory):
+    def __init__(self, directory=None, image_list=None):
         """
         Initialize the WorldView metadata reader.
 
+        The reader can be built either from a ``directory`` (its camera XMLs are
+        discovered) or from an explicit ``image_list`` of XML files (e.g. a
+        ``geom_plot *.XML`` invocation, where the shell has already expanded the
+        files). At least one of the two must be given.
+
         Parameters
         ----------
-        directory : str
-            Path to directory containing XML camera model files.
+        directory : str, optional
+            Path to directory containing XML camera model files. When
+            ``image_list`` is also given, this is used only as the base
+            directory for ``dg_mosaic`` outputs and the pair name.
+        image_list : list of str, optional
+            Explicit list of XML camera files to use instead of discovering
+            them from ``directory``. Non-camera XMLs (``README.XML``,
+            ``*ortho*.xml``) are still filtered out.
 
         Raises
         ------
         ValueError
-            If no XML files are found in the directory.
+            If neither ``directory`` nor ``image_list`` is given, or if no
+            camera XML files are found.
         """
-        super().__init__(directory)
+        if directory is None and image_list is None:
+            raise ValueError("Provide either a directory or an image_list.")
 
-        self.image_list = self._discover_xmls(self.directory)
+        if image_list is not None:
+            # Explicit file list (e.g. shell-expanded ``geom_plot *.XML``): use
+            # it directly, but still drop non-camera XMLs by name. Fall back to
+            # the files' common parent for mosaic output / pair naming when no
+            # directory is supplied.
+            self.image_list = self._filter_camera_xmls(image_list)
+            self.directory = (
+                os.path.expanduser(directory)
+                if directory
+                else _common_base(self.image_list)
+            )
+        else:
+            super().__init__(directory)
+            self.image_list = self._discover_xmls(self.directory)
 
         if not self.image_list:
             raise ValueError(
-                "\n\nMissing XML camera files in directory. Cannot extract metadata without these.\n\n"
+                "\n\nMissing XML camera files. Cannot extract metadata without these.\n\n"
             )
 
     # XML files that are delivered alongside the camera models but are *not*
@@ -220,6 +267,27 @@ class WorldViewMetadata(SensorMetadata):
             Whether WorldView XML camera files were found.
         """
         return bool(cls._discover_xmls(os.path.expanduser(directory)))
+
+    @classmethod
+    def detect_files(cls, image_list):
+        """Return True if any file in ``image_list`` is a camera XML.
+
+        The file-list counterpart of :meth:`detect`, used to choose a reader
+        for an explicit list of inputs (see :func:`sensor_for_inputs`). A file
+        is a camera XML if it survives the non-camera basename filter (so
+        ``README.XML`` / ``*ortho*.xml`` alone do not match).
+
+        Parameters
+        ----------
+        image_list : list of str
+            Candidate XML file paths.
+
+        Returns
+        -------
+        bool
+            Whether any camera XML files are present.
+        """
+        return bool(cls._filter_camera_xmls(image_list))
 
     def get_scene_dicts(self):
         """
@@ -639,6 +707,120 @@ class WorldViewMetadata(SensorMetadata):
 
 # Registry of available sensor readers, in detection-priority order.
 SENSORS = [WorldViewMetadata]
+
+
+def _common_base(paths):
+    """Return a base directory for a list of files.
+
+    Used to pick a working directory (for ``dg_mosaic`` outputs and pair
+    naming) when a reader is built from an explicit file list rather than a
+    directory. Returns the files' common parent directory, or the current
+    working directory if they share no common parent or the list is empty.
+    """
+    paths = [os.path.abspath(p) for p in (paths or [])]
+    if not paths:
+        return os.getcwd()
+    base = os.path.commonpath(paths) if len(paths) > 1 else os.path.dirname(paths[0])
+    # commonpath can return a file path if one entry is a prefix of another;
+    # make sure we hand back a directory.
+    return base if os.path.isdir(base) else os.path.dirname(base)
+
+
+def resolve_xml_inputs(inputs, recursive=True):
+    """Expand files, directories, and glob patterns into XML file paths.
+
+    Lets a user point the tools at messy inputs without a fixed directory
+    structure — e.g. ``geom_plot *.XML`` (already expanded by the shell),
+    ``geom_plot scene1.xml scene2.xml``, ``geom_plot delivery_dir/``, or a mix.
+
+    Each item of ``inputs`` may be:
+
+    - a path to an XML file (included directly),
+    - a directory (searched with :meth:`WorldViewMetadata._discover_xmls`, which
+      is shallow-first and falls back to a recursive search), or
+    - a glob pattern (expanded with :func:`glob.glob`).
+
+    Results are de-duplicated (by absolute path) and returned sorted. Note that
+    sensor-specific filtering of non-camera XMLs (``README.XML``, ortho
+    products) is applied by the reader, not here.
+
+    Parameters
+    ----------
+    inputs : str or os.PathLike or iterable of those
+        One or more files, directories, and/or glob patterns.
+    recursive : bool, optional
+        Passed through to directory discovery and ``**`` glob expansion.
+        Default True.
+
+    Returns
+    -------
+    list of str
+        Sorted, de-duplicated XML file paths.
+    """
+    if isinstance(inputs, (str, os.PathLike)):
+        inputs = [inputs]
+
+    collected = []
+    for item in inputs:
+        item = os.path.expanduser(str(item))
+        if os.path.isdir(item):
+            collected.extend(
+                WorldViewMetadata._discover_xmls(item, recursive=recursive)
+            )
+        elif glob.has_magic(item):
+            collected.extend(glob.glob(item, recursive=recursive))
+        elif os.path.isfile(item):
+            collected.append(item)
+        else:
+            logger.warning("Input does not exist, skipping: %s", item)
+
+    seen = set()
+    unique = []
+    for path in collected:
+        key = os.path.abspath(path)
+        if key not in seen:
+            seen.add(key)
+            unique.append(path)
+    return sorted(unique)
+
+
+def sensor_for_inputs(inputs):
+    """Detect and instantiate the appropriate sensor reader for explicit inputs.
+
+    The file-list counterpart of :func:`sensor_for_directory`. Resolves
+    ``inputs`` (files, directories, and/or globs) into a list of XML files,
+    then returns an instance of the first registered reader whose
+    :meth:`SensorMetadata.detect_files` matches.
+
+    Parameters
+    ----------
+    inputs : str or os.PathLike or iterable of those
+        One or more files, directories, and/or glob patterns.
+
+    Returns
+    -------
+    SensorMetadata
+        An initialized reader for the detected sensor.
+
+    Raises
+    ------
+    ValueError
+        If no XML files are found, or no registered sensor reader matches them.
+    """
+    image_list = resolve_xml_inputs(inputs)
+    if not image_list:
+        raise ValueError(
+            "\n\nNo XML files found for the given input(s). "
+            "Provide camera XML files, a directory, or a glob pattern.\n\n"
+        )
+    base = _common_base(image_list)
+    for sensor_cls in SENSORS:
+        if sensor_cls.detect_files(image_list):
+            return sensor_cls(directory=base, image_list=image_list)
+    raise ValueError(
+        "\n\nNo supported sensor metadata files found among the given input(s). "
+        f"Supported sensors: {', '.join(s.name for s in SENSORS)}.\n\n"
+    )
 
 
 def sensor_for_directory(directory):

--- a/asp_plot/stereo_geometry.py
+++ b/asp_plot/stereo_geometry.py
@@ -39,21 +39,29 @@ class StereoGeometryPlotter:
     >>> plotter.dg_geom_plot(save_dir='/path/to/output', fig_fn='stereo_geom.png')
     """
 
-    def __init__(self, directory, add_basemap=True, **kwargs):
+    def __init__(self, directory=None, add_basemap=True, inputs=None, **kwargs):
         """
         Initialize the StereoGeometryPlotter.
 
         Parameters
         ----------
-        directory : str
-            Path to directory containing XML camera model files
+        directory : str, optional
+            Path to directory containing XML camera model files.
         add_basemap : bool, optional
             Whether to add a contextily basemap to the plots, default is True
+        inputs : str or os.PathLike or iterable of those, optional
+            Explicit files, directories, and/or glob patterns to use instead of
+            a single ``directory`` (e.g. a ``geom_plot *.XML`` call). Takes
+            precedence when both are given.
         **kwargs
             Additional keyword arguments passed to StereopairMetadataParser
         """
-        self.directory = directory
-        self.parser = StereopairMetadataParser(directory=directory, **kwargs)
+        self.parser = StereopairMetadataParser(
+            directory=directory, inputs=inputs, **kwargs
+        )
+        # When built from an explicit input list, fall back to the parser's
+        # resolved base directory (used for default output paths).
+        self.directory = directory if directory is not None else self.parser.directory
         self.add_basemap = add_basemap
 
     def get_scene_string(self, p, key="catid1_dict"):

--- a/asp_plot/stereopair_metadata_parser.py
+++ b/asp_plot/stereopair_metadata_parser.py
@@ -7,7 +7,7 @@ import numpy as np
 from osgeo import osr
 from shapely import union_all
 
-from asp_plot.sensors import sensor_for_directory
+from asp_plot.sensors import sensor_for_directory, sensor_for_inputs
 from asp_plot.utils import get_utm_epsg
 
 osr.UseExceptions()
@@ -196,25 +196,38 @@ class StereopairMetadataParser:
     >>> print(f"Base-to-height ratio: {pair_dict['bh']}")
     """
 
-    def __init__(self, directory):
+    def __init__(self, directory=None, inputs=None):
         """
         Initialize the StereopairMetadataParser.
 
-        Detects the sensor from the directory contents and builds the matching
-        metadata reader.
+        Detects the sensor and builds the matching metadata reader, either from
+        a ``directory`` or from an explicit list of ``inputs`` (files,
+        directories, and/or glob patterns, e.g. a ``geom_plot *.XML`` call).
+        Exactly one of the two should be given.
 
         Parameters
         ----------
-        directory : str
-            Path to directory containing camera model / metadata files
+        directory : str, optional
+            Path to directory containing camera model / metadata files.
+        inputs : str or os.PathLike or iterable of those, optional
+            Explicit files, directories, and/or glob patterns to use instead of
+            a single ``directory``. Takes precedence when both are given.
 
         Raises
         ------
         ValueError
-            If no supported sensor metadata files are found in the directory
+            If neither ``directory`` nor ``inputs`` is given, or if no supported
+            sensor metadata files are found.
         """
-        self.directory = os.path.expanduser(directory)
-        self.reader = sensor_for_directory(self.directory)
+        if inputs is None and directory is None:
+            raise ValueError("Provide either a directory or inputs.")
+
+        if inputs is not None:
+            self.reader = sensor_for_inputs(inputs)
+            self.directory = self.reader.directory
+        else:
+            self.directory = os.path.expanduser(directory)
+            self.reader = sensor_for_directory(self.directory)
 
     @property
     def image_list(self):

--- a/docs/cli/stereo_geom.md
+++ b/docs/cli/stereo_geom.md
@@ -4,16 +4,33 @@ The `stereo_geom` command-line tool creates visualizations of stereo geometry fo
 
 ## Basic usage
 
+Pass the XML camera files directly. `INPUTS` may be any mix of XML files, directories, and glob patterns, and need not follow a fixed directory structure:
+
+```bash
+# A shell glob expands to the candidate XML files
+stereo_geom *.XML
+
+# Explicit files
+stereo_geom scene1.xml scene2.xml
+
+# A delivery directory (searched recursively for camera XMLs)
+stereo_geom my_delivery_dir/
+```
+
+Directories are searched recursively for camera XMLs, and non-camera files (e.g. `README.XML`, ortho `*_ortho.xml`) are skipped automatically. By default, the tool saves the output as `<directory_name>_stereo_geom.png` in the common input directory.
+
+## Using `--directory` instead
+
+When no positional `INPUTS` are given, the tool falls back to `--directory` (default: current directory). This is the original interface and remains supported:
+
 ```bash
 stereo_geom --directory /path/to/directory/with/xml/files
 ```
 
-By default, the tool saves the output as `<directory_name>_stereo_geom.png` in the input directory.
-
 ## Custom output location
 
 ```bash
-stereo_geom --directory /path/to/directory/with/xml/files \
+stereo_geom scene1.xml scene2.xml \
             --output_directory /path/to/save/plots \
             --output_filename custom_output.png
 ```
@@ -23,22 +40,33 @@ stereo_geom --directory /path/to/directory/with/xml/files \
 Adding a basemap to the map view requires an internet connection:
 
 ```bash
-stereo_geom --directory /path/to/directory/with/xml/files \
+stereo_geom my_delivery_dir/ \
             --add_basemap True
 ```
 
 ## Full options
 
 ```
-Usage: stereo_geom [OPTIONS]
+Usage: stereo_geom [OPTIONS] [INPUTS]...
 
-  Generate stereo geometry plots for DigitalGlobe/Maxar XML files. This tool
-  creates a skyplot and map visualization of the satellite positions and
-  ground footprints.
+  Generate stereo geometry plots for WorldView XML files.
+
+  This tool creates a skyplot and map visualization of the satellite positions
+  and ground footprints. INPUTS may be any mix of XML files, directories, and
+  glob patterns and need not follow a fixed directory structure, e.g.:
+
+      stereo_geom *.XML
+
+      stereo_geom scene1.xml scene2.xml
+
+      stereo_geom my_delivery_dir/
+
+  If no INPUTS are given, --directory is used (default: current directory).
 
 Options:
   --directory TEXT         Directory containing XML files for stereo geometry
-                           analysis. Default: current directory.
+                           analysis. Used when no positional INPUTS are given.
+                           Default: current directory.
   --add_basemap BOOLEAN    If True, add a basemap to the figures, which
                            requires internet connection. Default: True.
   --output_directory TEXT  Directory to save the output plot. Default: Input

--- a/tests/test_cli_stereo_geom.py
+++ b/tests/test_cli_stereo_geom.py
@@ -1,0 +1,73 @@
+import matplotlib
+from click.testing import CliRunner
+
+from asp_plot.cli.stereo_geom import main
+
+matplotlib.use("Agg")
+
+CAM_A = "tests/test_data/10300100D0772D00.r100.xml"
+CAM_B = "tests/test_data/10300100D12D7400.r100.xml"
+
+
+def _run(args):
+    # add_basemap False keeps the CLI offline (no contextily tile fetch).
+    return CliRunner().invoke(main, args + ["--add_basemap", "False"])
+
+
+class TestStereoGeomCli:
+    def test_positional_xml_files(self, tmp_path):
+        # The geom_plot *.XML case: shell hands the CLI a list of XML files.
+        out = tmp_path / "from_files.png"
+        result = _run(
+            [
+                CAM_A,
+                CAM_B,
+                "--output_directory",
+                str(tmp_path),
+                "--output_filename",
+                out.name,
+            ]
+        )
+        assert result.exit_code == 0, result.output
+        assert out.exists()
+
+    def test_glob_pattern(self, tmp_path):
+        out = tmp_path / "from_glob.png"
+        result = _run(
+            [
+                "tests/test_data/*.r100.xml",
+                "--output_directory",
+                str(tmp_path),
+                "--output_filename",
+                out.name,
+            ]
+        )
+        assert result.exit_code == 0, result.output
+        assert out.exists()
+
+    def test_directory_flag_still_works(self, tmp_path):
+        # Backward compatibility with the original --directory interface.
+        out = tmp_path / "from_flag.png"
+        result = _run(
+            [
+                "--directory",
+                "tests/test_data",
+                "--output_directory",
+                str(tmp_path),
+                "--output_filename",
+                out.name,
+            ]
+        )
+        assert result.exit_code == 0, result.output
+        assert out.exists()
+
+    def test_default_output_filename_from_directory(self, tmp_path):
+        # With no --output_filename, the name derives from the base directory.
+        result = _run([CAM_A, CAM_B, "--output_directory", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / "test_data_stereo_geom.png").exists()
+
+    def test_no_xml_inputs_errors(self, tmp_path):
+        (tmp_path / "note.txt").write_text("not xml")
+        result = _run(["--directory", str(tmp_path)])
+        assert result.exit_code != 0

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -9,7 +9,9 @@ from asp_plot.sensors import (
     SENSORS,
     SensorMetadata,
     WorldViewMetadata,
+    resolve_xml_inputs,
     sensor_for_directory,
+    sensor_for_inputs,
 )
 
 # The two committed single-scene WorldView camera XMLs at the top level of
@@ -152,6 +154,79 @@ class TestWorldViewDiscovery:
         nested.mkdir(parents=True)
         shutil.copy(CAM_A, nested / "camera.xml")
         assert WorldViewMetadata.detect(str(tmp_path)) is True
+
+
+class TestFlexibleInputResolution:
+    """Resolving files / directories / globs into camera XMLs (geom_plot *.XML)."""
+
+    def test_resolve_explicit_files(self):
+        # The shell-expanded ``geom_plot *.XML`` case: a list of file paths.
+        found = resolve_xml_inputs([str(CAM_A), str(CAM_B)])
+        assert found == sorted([str(CAM_A), str(CAM_B)])
+
+    def test_resolve_directory(self):
+        # A bare directory is discovered the same way as the directory API.
+        found = resolve_xml_inputs(str(TEST_DATA_DIR))
+        assert set(found) == {str(CAM_A), str(CAM_B)}
+
+    def test_resolve_glob_pattern(self):
+        found = resolve_xml_inputs(str(TEST_DATA_DIR / "*.r100.xml"))
+        assert set(found) == {str(CAM_A), str(CAM_B)}
+
+    def test_resolve_single_string_not_iterated_per_char(self):
+        # A lone path string must be treated as one path, not a char iterable.
+        found = resolve_xml_inputs(str(CAM_A))
+        assert found == [str(CAM_A)]
+
+    def test_resolve_mixed_inputs_deduplicated(self, tmp_path):
+        # A file, a directory, and a glob that all reference overlapping XMLs
+        # collapse to a de-duplicated, sorted set.
+        shutil.copy(CAM_A, tmp_path / "a.xml")
+        shutil.copy(CAM_B, tmp_path / "b.xml")
+        found = resolve_xml_inputs(
+            [
+                str(tmp_path / "a.xml"),
+                str(tmp_path),  # also discovers a.xml and b.xml
+                str(tmp_path / "*.xml"),  # again
+            ]
+        )
+        assert found == sorted([str(tmp_path / "a.xml"), str(tmp_path / "b.xml")])
+
+    def test_resolve_finds_nested_xml(self, tmp_path):
+        # A directory input still descends into deeply-nested deliveries.
+        nested = tmp_path / "order" / "scene_PAN"
+        nested.mkdir(parents=True)
+        shutil.copy(CAM_A, nested / "camera.xml")
+        found = resolve_xml_inputs(str(tmp_path))
+        assert [Path(f).name for f in found] == ["camera.xml"]
+
+    def test_resolve_missing_input_skipped(self, tmp_path, caplog):
+        with caplog.at_level("WARNING"):
+            found = resolve_xml_inputs(
+                [str(CAM_A), str(tmp_path / "does_not_exist.xml")]
+            )
+        assert found == [str(CAM_A)]
+        assert "does not exist" in caplog.text
+
+    def test_sensor_for_inputs_returns_reader(self):
+        reader = sensor_for_inputs([str(CAM_A), str(CAM_B)])
+        assert isinstance(reader, WorldViewMetadata)
+        assert set(reader.image_list) == {str(CAM_A), str(CAM_B)}
+
+    def test_sensor_for_inputs_no_xml_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="No XML files found"):
+            sensor_for_inputs([str(tmp_path / "nope.xml")])
+
+    def test_reader_from_image_list_filters_non_camera(self, tmp_path):
+        # README/ortho decoys handed in explicitly are still dropped.
+        readme = tmp_path / "500647760070_01_README.XML"
+        readme.write_text("<README/>")
+        reader = WorldViewMetadata(image_list=[str(CAM_A), str(readme)])
+        assert reader.image_list == [str(CAM_A)]
+
+    def test_reader_requires_directory_or_image_list(self):
+        with pytest.raises(ValueError, match="either a directory or an image_list"):
+            WorldViewMetadata()
 
 
 class TestWorldViewSceneGrouping:

--- a/tests/test_stereopair_metadata_parser.py
+++ b/tests/test_stereopair_metadata_parser.py
@@ -25,6 +25,23 @@ class TestStereopairMetadataParser:
         # Parser is sensor-agnostic and delegates to a detected reader
         assert isinstance(parser.reader, WorldViewMetadata)
 
+    def test_inputs_file_list_matches_directory(self, parser):
+        # Building from an explicit XML file list (geom_plot *.XML) yields the
+        # same pair geometry as pointing at the directory.
+        files = [
+            "tests/test_data/10300100D0772D00.r100.xml",
+            "tests/test_data/10300100D12D7400.r100.xml",
+        ]
+        parser_from_files = StereopairMetadataParser(inputs=files)
+        assert isinstance(parser_from_files.reader, WorldViewMetadata)
+        assert parser_from_files.get_pair_dict()["conv_ang"] == pytest.approx(
+            parser.get_pair_dict()["conv_ang"]
+        )
+
+    def test_requires_directory_or_inputs(self):
+        with pytest.raises(ValueError, match="either a directory or inputs"):
+            StereopairMetadataParser()
+
     def test_image_list_delegates_to_reader(self, parser):
         assert parser.image_list is parser.reader.image_list
         assert len(parser.image_list) > 0


### PR DESCRIPTION
Part of #73 (does **not** close it).

Issue #73 asks that a user be able to make stereo-geometry plots for candidate scenes with `geom_plot *.XML`, without an assumed directory structure. Previously `stereo_geom` only accepted a single `--directory`.

## What this adds
`stereo_geom` now accepts any mix of **XML files, directories, and glob patterns** as positional arguments:

```bash
stereo_geom *.XML                    # shell-expanded list of files
stereo_geom scene1.xml scene2.xml    # explicit files
stereo_geom my_delivery_dir/         # a directory (recursive discovery, as before)
stereo_geom "data/**/*.XML"          # a quoted glob
```

The original interface is unchanged — `stereo_geom --directory ./` and the `directory=` Python API behave exactly as before, so existing callers and the report pipeline are unaffected.

## How
- **`sensors.py`**
  - `resolve_xml_inputs()` — expand a str/list of files, dirs, and globs into a de-duplicated, sorted XML list (dirs via the existing shallow-first `_discover_xmls`, globs via `glob`, files directly).
  - `SensorMetadata.detect_files()` + `sensor_for_inputs()` — file-list counterparts of `detect()` / `sensor_for_directory()`.
  - `WorldViewMetadata` can be built from an explicit `image_list` (still filters out `README.XML` / `*ortho*.xml`), using the files common parent as the base dir for `dg_mosaic` output and pair naming.
- **`stereopair_metadata_parser.py` / `stereo_geometry.py`** — thread an optional `inputs=` alongside `directory=`.
- **`cli/stereo_geom.py`** — variadic positional `INPUTS`; positional wins, else fall back to `--directory` (default `./`).

## Scope
Still **pair-only** (exactly two scenes). N-scene multi-view geometry (the Utqiagvik-style 7-scene skyplot, with full per-pair metrics) is the remaining part of #73 and will follow in a separate PR.

## Tests
- `test_sensors.py::TestFlexibleInputResolution` — files / dirs / globs / mixed+dedupe / nested / missing-input / `sensor_for_inputs` / reader-from-list / non-camera filtering.
- `test_stereopair_metadata_parser.py` — `inputs=` matches the directory result; requires one of directory/inputs.
- `test_cli_stereo_geom.py` (new) — all four CLI input forms + default output naming + no-XML error.

Full suite: **379 passed** locally.