### PR TITLE
Sync the conda reference recipe with actual deps; document the autotick bot's blind spot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,8 @@ Follow semantic versioning. To release:
 
 The rest is automated: `release.yml` detects the version bump, creates a GitHub Release + tag, and publishes to PyPI via OIDC trusted publishing; conda-forge's autotick bot then opens a feedstock PR. PyPI trusted publishing and the conda-forge feedstock are already configured (reference recipe in `conda-forge-recipe/meta.yaml`).
 
+**The autotick bot only bumps `version` and `sha256` — it never syncs dependencies or entry points.** So whenever you add/remove a runtime dependency in `pyproject.toml` or add/rename a `[project.scripts]` entry point, the feedstock's `recipe/meta.yaml` must be edited by hand in the same release (`requirements: run:` and `build: entry_points:` + the matching `test: commands:`). Otherwise the conda build *succeeds* and then fails its own test phase, conda-build moves the package to `broken/`, and **nothing is uploaded** — PyPI advances while conda-forge silently stalls on the last good version. This is not hypothetical: adding `pyyaml` in v1.16.0 (#121) went unmirrored and stalled conda-forge at 1.15.1 for five releases (1.16.0 → 1.19.0), with a red ✗ on the feedstock's default branch the whole time. After releasing, check <https://anaconda.org/conda-forge/asp-plot> actually advanced rather than assuming the bot handled it.
+
 ## Common File Patterns
 
 ASP output files follow specific naming patterns (find them with the `glob_file()` utility):

--- a/conda-forge-recipe/meta.yaml
+++ b/conda-forge-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "asp-plot" %}
-{% set version = "1.6.3" %}
+{% set version = "2.0.0" %}
 {% set python_min = "3.11" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/asp_plot-{{ version }}.tar.gz
-  sha256: 28f66b0e9dcfbc225ade94cff70464a444b1c0c1f109e2d11cdc0e72cbe648f5
+  sha256: 0a3f6725fd893c3058f120810f5f123bcf9ad712495431918c7ca4172ee06a53
 
 build:
   noarch: python
@@ -18,6 +18,8 @@ build:
     - asp_report = asp_plot.cli.asp_report:main
     - csm_camera_plot = asp_plot.cli.csm_camera_plot:main
     - stereo_geom = asp_plot.cli.stereo_geom:main
+    - request_planetary_altimetry = asp_plot.cli.request_planetary_altimetry:main
+    - gallery = asp_plot.cli.gallery:main
 
 requirements:
   host:
@@ -40,7 +42,8 @@ requirements:
     - rioxarray
     - scipy
     - shapely
-    - sliderule
+    - pyyaml
+    - sliderule >=5.3.0
     - xarray
 
 test:
@@ -50,6 +53,8 @@ test:
     - asp_report --help
     - csm_camera_plot --help
     - stereo_geom --help
+    - request_planetary_altimetry --help
+    - gallery --help
 
 about:
   home: https://github.com/uw-cryo/asp_plot


### PR DESCRIPTION
Groundwork for unsticking conda-forge, which has been **stalled at v1.15.1 since 2026-06-11** while PyPI advanced through 1.16.0, 1.17.0, 1.18.0, 1.18.1, 1.19.0 and now 2.0.0.

## Diagnosis

`pyyaml` became a runtime dependency in **v1.16.0** ([#121](https://github.com/uw-cryo/asp_plot/issues/121), `selections.py`) but was never added to the feedstock recipe. The autotick bot bumps only `version` and `sha256`, so every build since has compiled fine and then failed its own test phase:

```
+ asp_plot --help
  File ".../asp_plot/selections.py", line 25, in <module>
    import yaml
ModuleNotFoundError: No module named 'yaml'
WARNING: Tests failed for asp-plot-1.19.0-pyhd8ed1ab_0.conda - moving package to .../broken
```

conda-build moves a test-failing package to `broken/` and uploads nothing — so the failure was invisible except as a red ✗ on the feedstock's default branch. Five releases' worth of bot PRs were merged on top of it.

## What this PR changes (this repo only)

`conda-forge-recipe/meta.yaml` — the reference copy — had drifted four ways:

| Drift | Fix |
|---|---|
| `pyyaml` missing from `run:` | added — **this is the build failure** |
| `sliderule` unpinned (pyproject wants `>=5.3.0`) | pinned |
| `request_planetary_altimetry` + `gallery` entry points missing | added, with `--help` smoke tests |
| version/sha256 stuck at 1.6.3 | 2.0.0 + current sdist sha256 |

`AGENTS.md`'s release section now records the bot's blind spot: it syncs neither dependencies nor entry points, a mismatch fails in the *test* phase so nothing uploads, and the check after a release is that <https://anaconda.org/conda-forge/asp-plot> actually advanced.

## Not in this PR

The feedstock itself (`conda-forge/asp-plot-feedstock`) still needs its own PR — that repo is outside this one and I have not touched it. Beyond `pyyaml`, it also needs the v2.0.0 entry-point rename: it currently declares `asp_plot = asp_plot.cli.asp_plot:main`, a module that no longer exists as of 2.0.0, so fixing only `pyyaml` would trade one test failure for another.